### PR TITLE
Web list metas

### DIFF
--- a/lib/plenario2/queries/meta_queries.ex
+++ b/lib/plenario2/queries/meta_queries.ex
@@ -1,0 +1,18 @@
+defmodule Plenario2.Queries.MetaQueries do
+  import Ecto.Query
+  alias Plenario2.Schemas.Meta
+
+  def list(), do: (from m in Meta)
+
+  def with_user(query), do: from m in query, preload: [user: :metas]
+
+  # def with_data_set_fields(query), do: from m in query, preload: [data_set_fields: :metas]
+  #
+  # def with_data_set_constraints(query), do: from m in query, preload: [data_set_constraints: :metas]
+  #
+  # def with_virtual_date_fields(query), do: from m in query, preload: [virtual_date_fields: :metas]
+  #
+  # def with_virtual_point_fields(query), do: from m in query, preload: [virtual_point_fields: :metas]
+  #
+  # def with_data_set_diffs(query), do: from m in query, preload: [data_set_diffs: :metas]
+end

--- a/lib/plenario2_web/controllers/meta_controller.ex
+++ b/lib/plenario2_web/controllers/meta_controller.ex
@@ -6,8 +6,7 @@ defmodule Plenario2Web.MetaController do
   alias Plenario2.Changesets.MetaChangesets
 
   def list(conn, _params) do
-    metas = MetaActions.list()
-
+    metas = MetaActions.list([with_user: true])
     render(conn, "list.html", metas: metas)
   end
 

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -37,15 +37,15 @@ defmodule Plenario2Web.Router do
     post  "/register",  AuthController, :do_register
 
     # meta paths
-    get "/metas/list", MetaController, :list
+    get "/datasets/list", MetaController, :list
   end
 
   scope "/", Plenario2Web do
     pipe_through [:browser, :auth, :ensure_auth]
 
     # meta paths
-    get "/metas/create", MetaController, :create
-    post "/metas/create", MetaController, :do_create
+    get "/datasets/create", MetaController, :create
+    post "/datasets/create", MetaController, :do_create
   end
 
   # Other scopes may use custom stacks.

--- a/lib/plenario2_web/templates/meta/list.html.eex
+++ b/lib/plenario2_web/templates/meta/list.html.eex
@@ -1,7 +1,10 @@
-<h2>Metas</h2>
+<h2>Datasets</h2>
 
 <%= for meta <- @metas do %>
   <div>
-    <%= meta.name %>
+    <p>
+      <h4><%= meta.name %></h4>
+      <em>Maintainer:</em> <%= meta.user.name %>
+    </p>
   </div>
 <% end %>

--- a/test/plenario2_web/controllers/meta_controller_test.exs
+++ b/test/plenario2_web/controllers/meta_controller_test.exs
@@ -37,7 +37,7 @@ defmodule Plenario2Web.MetaControllerTest do
       conn = get(recycle(conn), redir_path)
       response = html_response(conn, 200)
 
-      assert response =~ "Metas"
+      assert response =~ "Datasets"
       assert response =~ "Test Data"
 
       assert length(MetaActions.list()) == 1
@@ -71,7 +71,8 @@ defmodule Plenario2Web.MetaControllerTest do
       |> get(meta_path(conn, :list))
       |> html_response(200)
 
-    assert response =~ "Metas"
+    assert response =~ "Datasets"
     assert response =~ "Test Data"
+    assert response =~ "Test User"
   end
 end

--- a/test/plenario2_web/controllers/meta_controller_test.exs
+++ b/test/plenario2_web/controllers/meta_controller_test.exs
@@ -33,7 +33,7 @@ defmodule Plenario2Web.MetaControllerTest do
       assert length(MetaActions.list()) == 0
 
       conn = post(conn, meta_path(conn, :do_create), %{"meta" => %{"name" => "Test Data", "source_url" => "https://example.com/test-data"}})
-      assert "/metas/list" = redir_path = redirected_to(conn, 302)
+      assert "/datasets/list" = redir_path = redirected_to(conn, 302)
       conn = get(recycle(conn), redir_path)
       response = html_response(conn, 200)
 


### PR DESCRIPTION
- changed `/metas` to `/datasets` in the router
- beefed up controller and template
- added new `queries` context to core lib

the new `queries` is intended to work as a means to standardize queries
and make them composable. rather than having

```
Repo.all(from m in Meta, where: m.state == "active", preload: [user:
:metas])
```

all over the place, i think it's nicer to see

```
MetaQueries.list()
|> MetaQueries.with_user()
|> MetaQueries.active_state()
|> Repo.all()
```

