### PR TITLE
Workflow for adding new fields to datasets

### DIFF
--- a/lib/plenario2/changesets/data_set_field_changesets.ex
+++ b/lib/plenario2/changesets/data_set_field_changesets.ex
@@ -1,6 +1,13 @@
 defmodule Plenario2.Changesets.DataSetFieldChangesets do
   import Ecto.Changeset
 
+  def create(struct) do
+    struct
+    |> cast(%{}, [:name, :type, :opts, :meta_id])
+    |> validate_required([:name, :type, :opts, :meta_id])
+    |> cast_assoc(:meta)
+  end
+
   def create(struct, params) do
     struct
     |> cast(params, [:name, :type, :opts, :meta_id])

--- a/lib/plenario2/changesets/data_set_field_changesets.ex
+++ b/lib/plenario2/changesets/data_set_field_changesets.ex
@@ -1,14 +1,7 @@
 defmodule Plenario2.Changesets.DataSetFieldChangesets do
   import Ecto.Changeset
 
-  def create(struct) do
-    struct
-    |> cast(%{}, [:name, :type, :opts, :meta_id])
-    |> validate_required([:name, :type, :opts, :meta_id])
-    |> cast_assoc(:meta)
-  end
-
-  def create(struct, params) do
+  def create(struct, params \\ %{}) do
     struct
     |> cast(params, [:name, :type, :opts, :meta_id])
     |> validate_required([:name, :type, :opts, :meta_id])
@@ -26,11 +19,15 @@ defmodule Plenario2.Changesets.DataSetFieldChangesets do
   # operations
 
   defp check_name(changeset) do
-    name =
-      get_field(changeset, :name)
-      |> String.split(~r/\s/, trim: true)
-      |> Enum.map(&String.downcase(&1))
-      |> Enum.join("_")
+    name = case get_field(changeset, :name) do
+      nil -> 
+        nil
+
+      name ->
+        String.split(name, ~r/\s/, trim: true)
+        |> Enum.map(&String.downcase(&1))
+        |> Enum.join("_")
+    end
 
     changeset |> put_change(:name, name)
   end

--- a/lib/plenario2/queries/meta_queries.ex
+++ b/lib/plenario2/queries/meta_queries.ex
@@ -21,7 +21,7 @@ defmodule Plenario2.Queries.MetaQueries do
 
   def with_user(query), do: from m in query, preload: [user: :metas]
 
-  def with_data_set_fields(query), do: from m in query, preload: [data_set_fields: :metas]
+  def with_data_set_fields(query), do: from m in query, preload: [data_set_fields: :meta]
 
   def with_data_set_constraints(query), do: from m in query, preload: [data_set_constraints: :metas]
 

--- a/lib/plenario2_web/controllers/data_set_field_controller.ex
+++ b/lib/plenario2_web/controllers/data_set_field_controller.ex
@@ -5,35 +5,25 @@ defmodule Plenario2Web.DataSetFieldController do
   alias Plenario2.Schemas.DataSetField
   use Plenario2Web, :controller
 
-  def index(conn, params) do
-    slug = params["data_set_slug"]
+  def index(conn, %{"slug" => slug}) do
     meta = MetaActions.get_from_slug(slug)
     fields = DataSetFieldActions.list_for_meta(meta)
 
-    render conn, "index.html", slug: slug, meta: meta, fields: fields
+    render(conn, "index.html", slug: slug, meta: meta, fields: fields)
   end
 
-  def new(conn, params) do
-    slug = params["data_set_slug"]
+  def new(conn, %{"slug" => slug}) do
     meta = MetaActions.get_from_slug(slug)
     source = meta.source_url
     changeset = DataSetFieldChangesets.create %DataSetField{}
     
-    render conn, "new.html", [
-      changeset: changeset, 
-      slug: slug
-    ]
+    render(conn, "new.html", [changeset: changeset, slug: slug])
   end
 
-  def create(conn, params) do
-    data_set_field_params = params["data_set_field"]
-    slug = params["data_set_slug"]
+  def create(conn, %{"data_set_field" => params, "slug" => slug}) do
     meta = MetaActions.get_from_slug(slug)
-
-    changeset = DataSetFieldChangesets.create(
-      %DataSetField{}, 
-      Map.merge(data_set_field_params, %{"meta_id" => meta.id})
-    )
+    changeset_params = Map.merge(params, %{"meta_id" => meta.id})
+    changeset = DataSetFieldChangesets.create(%DataSetField{}, changeset_params)
 
    case Repo.insert(changeset) do
       {:ok, field} ->
@@ -43,9 +33,5 @@ defmodule Plenario2Web.DataSetFieldController do
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset, slug: slug)
     end
-  end
-
-  def show(conn, params) do
-
   end
 end

--- a/lib/plenario2_web/controllers/data_set_field_controller.ex
+++ b/lib/plenario2_web/controllers/data_set_field_controller.ex
@@ -1,5 +1,7 @@
 defmodule Plenario2Web.DataSetFieldController do
   alias Plenario2.Actions.{DataSetFieldActions, MetaActions}
+  alias Plenario2.Changesets.DataSetFieldChangesets
+  alias Plenario2.Repo
   alias Plenario2.Schemas.DataSetField
   use Plenario2Web, :controller
 
@@ -7,19 +9,43 @@ defmodule Plenario2Web.DataSetFieldController do
     slug = params["data_set_slug"]
     meta = MetaActions.get_from_slug(slug)
     fields = DataSetFieldActions.list_for_meta(meta)
+
     render conn, "index.html", slug: slug, meta: meta, fields: fields
   end
 
-  def show(conn, params) do
-
-  end
-
   def new(conn, params) do
-    changeset = DataSetField.changeset %DataSetField{}
-    render conn, "new.html", changeset: changeset
+    slug = params["data_set_slug"]
+    meta = MetaActions.get_from_slug(slug)
+    source = meta.source_url
+    changeset = DataSetFieldChangesets.create %DataSetField{}
+    
+    render conn, "new.html", [
+      changeset: changeset, 
+      slug: slug
+    ]
   end
 
   def create(conn, params) do
+    data_set_field_params = params["data_set_field"]
+    slug = params["data_set_slug"]
+    meta = MetaActions.get_from_slug(slug)
+
+    changeset = DataSetFieldChangesets.create(
+      %DataSetField{}, 
+      Map.merge(data_set_field_params, %{"meta_id" => meta.id})
+    )
+
+   case Repo.insert(changeset) do
+      {:ok, field} ->
+        conn
+        |> put_flash(:info, "#{field.name} created!")
+        |> redirect(to: data_set_field_path(conn, :index, slug))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset, slug: slug)
+    end
+  end
+
+  def show(conn, params) do
 
   end
 end

--- a/lib/plenario2_web/controllers/data_set_field_controller.ex
+++ b/lib/plenario2_web/controllers/data_set_field_controller.ex
@@ -1,0 +1,25 @@
+defmodule Plenario2Web.DataSetFieldController do
+  alias Plenario2.Actions.{DataSetFieldActions, MetaActions}
+  alias Plenario2.Schemas.DataSetField
+  use Plenario2Web, :controller
+
+  def index(conn, params) do
+    slug = params["data_set_slug"]
+    meta = MetaActions.get_from_slug(slug)
+    fields = DataSetFieldActions.list_for_meta(meta)
+    render conn, "index.html", slug: slug, meta: meta, fields: fields
+  end
+
+  def show(conn, params) do
+
+  end
+
+  def new(conn, params) do
+    changeset = DataSetField.changeset %DataSetField{}
+    render conn, "new.html", changeset: changeset
+  end
+
+  def create(conn, params) do
+
+  end
+end

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -61,6 +61,8 @@ defmodule Plenario2Web.Router do
     put "/data-sets/:slug/update/source", MetaController, :do_update_source_info
     get "/data-sets/:slug/update/refresh", MetaController, :get_update_refresh_info
     put "/data-sets/:slug/update/refresh", MetaController, :do_update_refresh_info
+
+    resources "/data-sets/:data_set_slug/fields", DataSetFieldController
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -63,7 +63,7 @@ defmodule Plenario2Web.Router do
     put "/data-sets/:slug/update/refresh", MetaController, :do_update_refresh_info
     post "/data-sets/:slug/submit-for-approval", MetaController, :submit_for_approval
 
-    resources "/data-sets/:data_set_slug/fields", DataSetFieldController
+    resources "/data-sets/:slug/fields", DataSetFieldController
 
     post "/notes/:id/acknowledge", AdminUserNoteController, :acknowledge
   end

--- a/lib/plenario2_web/templates/data_set_field/index.html.eex
+++ b/lib/plenario2_web/templates/data_set_field/index.html.eex
@@ -1,0 +1,13 @@
+<!-- Template Variables -->
+<!-- ================== -->
+<!-- slug        charlist -->
+<!-- meta        Meta -->
+<!-- fields      list[DataSetField] -->
+
+<h2>Data Set Fields</h2>
+<h5><%= @meta.name %></h5>
+
+<%= for field <- @fields do %>
+<% end %>
+
+

--- a/lib/plenario2_web/templates/data_set_field/index.html.eex
+++ b/lib/plenario2_web/templates/data_set_field/index.html.eex
@@ -1,13 +1,28 @@
 <!-- Template Variables -->
 <!-- ================== -->
-<!-- slug        charlist -->
 <!-- meta        Meta -->
 <!-- fields      list[DataSetField] -->
 
 <h2>Data Set Fields</h2>
 <h5><%= @meta.name %></h5>
 
-<%= for field <- @fields do %>
-<% end %>
-
-
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Name</th>
+      <th scope="col">Type</th>
+      <th scope="col">Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for field <- @fields do %>
+      <tr>
+          <th><%= field.id %></th>
+          <td><%= field.name %></td>
+          <td><%= field.type %></td>
+          <td><%= field.opts %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table> 

--- a/lib/plenario2_web/templates/data_set_field/new.html.eex
+++ b/lib/plenario2_web/templates/data_set_field/new.html.eex
@@ -1,0 +1,31 @@
+<!-- Template Variables -->
+<!-- ================== -->
+<!-- meta        Meta -->
+<!-- fields      list[DataSetField] -->
+<!-- slug        charlist -->
+
+<h2>Register New Data Set Field</h2>
+
+<%= form_for @changeset, data_set_field_path(@conn, :create, @slug), fn f -> %>
+  <div class="form-group">
+    <%= label f, "Field Name", class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, "Type", class: "control-label" %>
+    <%= text_input f, :type, class: "form-control" %>
+    <%= error_tag f, :type %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, "Modifiers", class: "control-label" %>
+    <%= text_input f, :opts, class: "form-control" %>
+    <%= error_tag f, :opts %>
+  </div>
+
+  <div class="from-group">
+    <%= submit "Create", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/lib/plenario2_web/views/data_set_field_view.ex
+++ b/lib/plenario2_web/views/data_set_field_view.ex
@@ -1,0 +1,3 @@
+defmodule Plenario2Web.DataSetFieldView do
+  use Plenario2Web, :view
+end

--- a/test/plenario2_web/controllers/data_set_field_controller_test.exs
+++ b/test/plenario2_web/controllers/data_set_field_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule Plenario2Web.DataSetFieldControllerTest do
+  use Plenario2Web.ConnCase, async: true
+  alias Plenario2.Actions.{DataSetFieldActions, MetaActions}
+  alias Plenario2Auth.UserActions
+
+  @user_name "user"
+  @user_password "password"
+  @user_email "email@example.com"
+
+  @meta_name "test"
+  @meta_source_url "somewhere"
+  
+  setup do
+    {:ok, user} = UserActions.create(@user_name, @user_password, @user_email)
+    {:ok, meta} = MetaActions.create(@meta_name, user.id, @meta_source_url)
+
+    %{
+      meta: meta,
+      user: user
+    }
+  end
+
+  describe "GET :new" do
+    test "when anonymous", %{conn: conn} do
+      response = conn
+        |> get(data_set_field_path(conn, :new, "some slug"))
+        |> response(:unauthorized)
+
+      assert response =~ "unauthorized"
+    end
+
+    test "when logged in", %{conn: conn, meta: meta} do
+      conn = post(conn, auth_path(conn, :do_login, %{
+        "user" => %{
+          "email_address" => @user_email, 
+          "plaintext_password" => @user_password
+        }
+      }))
+
+      response = conn
+        |> get(data_set_field_path(conn, :new, meta.slug))
+        |> response(200)
+
+      assert response =~ "New Data Set Field"
+    end
+  end
+
+  describe "POST :create" do
+    test "when anonymous", %{conn: conn} do
+      response = conn
+        |> get(data_set_field_path(conn, :create, "some slug"))
+        |> response(:unauthorized)
+
+      assert response =~ "unauthorized"
+    end
+
+    test "when logged in", %{conn: conn, meta: meta} do
+      conn = post(conn, auth_path(conn, :do_login, %{
+        "user" => %{
+          "email_address" => @user_email, 
+          "plaintext_password" => @user_password
+        }
+      }))
+
+      response = conn
+        |> post(data_set_field_path(conn, :create, meta.slug), %{
+          "data_set_field" => %{
+            "name" => "foo",
+            "type" => "bar",
+            "opts" => "baz"
+          }
+        })
+        |> response(302)
+
+      fields = DataSetFieldActions.list_for_meta(meta)
+
+      assert Enum.count(fields) == 1
+    end
+  end
+end

--- a/test/plenario2_web/controllers/data_set_field_controller_test.exs
+++ b/test/plenario2_web/controllers/data_set_field_controller_test.exs
@@ -62,7 +62,7 @@ defmodule Plenario2Web.DataSetFieldControllerTest do
         }
       }))
 
-      response = conn
+      conn
         |> post(data_set_field_path(conn, :create, meta.slug), %{
           "data_set_field" => %{
             "name" => "foo",


### PR DESCRIPTION
- Adds a `DataSetField` controller with actions for adding and associating new fields to `Meta` instances
- Adds a form for creating these fields
- Adds a simple index page at `/data-sets/:slug/fields`