### PR TITLE
Self management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ erl_crash.dump
 npm-debug.log
 
 # Static artifacts
+node_modules/
 /assets/node_modules
 
 # Since we are building assets from assets/,

--- a/lib/plenario2/actions/admin_user_note_actions.ex
+++ b/lib/plenario2/actions/admin_user_note_actions.ex
@@ -2,8 +2,19 @@ defmodule Plenario2.Actions.AdminUserNoteActions do
   alias Plenario2.Repo
   alias Plenario2.Schemas.AdminUserNote
   alias Plenario2.Changesets.AdminUserNoteChangesets
+  alias Plenario2.Queries.AdminUserNoteQueries, as: Q
 
-  def get_from_id(id), do: Repo.get_by(AdminUserNote, id: id)
+  def get_from_id(id, opts \\ []) do
+    Q.from_id(id)
+    |> Q.handle_opts(opts)
+    |> Repo.one()
+  end
+
+  def list(opts \\ []) do
+    Q.list()
+    |> Q.handle_opts(opts)
+    |> Repo.all()
+  end
 
   def create_for_meta(note, admin, user, meta, should_email \\ false) do
     params = %{

--- a/lib/plenario2/queries/admin_user_note_queries.ex
+++ b/lib/plenario2/queries/admin_user_note_queries.ex
@@ -1,0 +1,35 @@
+defmodule Plenario2.Queries.AdminUserNoteQueries do
+  import Ecto.Query
+  import Plenario2.Queries.Utils
+
+  alias Plenario2.Schemas.AdminUserNote
+  alias Plenario2.Queries.AdminUserNoteQueries
+
+  def from_id(id), do: (from n in AdminUserNote, where: n.id == ^id)
+
+  def list(), do: (from n in AdminUserNote)
+
+  def unread(query), do: from n in query, where: n.acknowledged == false
+
+  def acknowledged(query), do: from n in query, where: n.acknowledged == true
+
+  def for_user(query, user), do: from n in query, where: n.user_id == ^user.id
+
+  def oldest_first(query), do: from n in query, order_by: [desc: n.inserted_at]
+
+  def handle_opts(query, opts \\ []) do
+    defaults = [
+      unread: false,
+      acknowledged: false,
+      for_user: nil,
+      oldest: false
+    ]
+    opts = Keyword.merge(defaults, opts)
+
+    query
+    |> cond_compose(opts[:unread], AdminUserNoteQueries, :unread)
+    |> cond_compose(opts[:acknowledged], AdminUserNoteQueries, :acknowledged)
+    |> cond_compose(opts[:oldest_first], AdminUserNoteQueries, :oldest_first)
+    |> filter_compose(opts[:for_user], AdminUserNoteQueries, :for_user)
+  end
+end

--- a/lib/plenario2/queries/meta_queries.ex
+++ b/lib/plenario2/queries/meta_queries.ex
@@ -36,6 +36,16 @@ defmodule Plenario2.Queries.MetaQueries do
   ##
   # filters
 
+  def new(query), do: from m in query, where: m.state == "new"
+
+  def needs_approval(query), do: from m in query, where: m.state == "needs_approval"
+
+  def ready(query), do: from m in query, where: m.state == "ready"
+
+  def erred(query), do: from m in query, where: m.state == "erred"
+
+  def limit_to(query, limit), do: from m in query, limit: ^limit
+
   def for_user(query, user), do: from m in query, where: m.user_id == ^user.id
 
   ##
@@ -49,6 +59,11 @@ defmodule Plenario2.Queries.MetaQueries do
       with_constraints: false,
       with_diffs: false,
       with_notes: false,
+      new: false,
+      needs_approval: false,
+      ready: false,
+      erred: false,
+      limit_to: nil,
       for_user: nil
     ]
     opts = Keyword.merge(defaults, opts)
@@ -61,6 +76,11 @@ defmodule Plenario2.Queries.MetaQueries do
     |> cond_compose(opts[:with_constraints], MetaQueries, :with_data_set_constraints)
     |> cond_compose(opts[:with_diffs], MetaQueries, :with_data_set_diffs)
     |> cond_compose(opts[:with_notes], MetaQueries, :with_admin_user_notes)
+    |> cond_compose(opts[:new], MetaQueries, :new)
+    |> cond_compose(opts[:needs_approval], MetaQueries, :needs_approval)
+    |> cond_compose(opts[:ready], MetaQueries, :ready)
+    |> cond_compose(opts[:erred], MetaQueries, :erred)
+    |> filter_compose(opts[:limit_to], MetaQueries, :limit_to)
     |> filter_compose(opts[:for_user], MetaQueries, :for_user)
   end
 end

--- a/lib/plenario2_auth/guardian.ex
+++ b/lib/plenario2_auth/guardian.ex
@@ -3,11 +3,11 @@ defmodule Plenario2Auth.Guardian do
   alias Plenario2Auth.UserActions
 
   def subject_for_token(user, _claims) do
-    {:ok, user.email_address}
+    {:ok, user.id}
   end
 
   def resource_from_claims(claims) do
-    user = UserActions.get_from_email(claims["sub"])
+    user = UserActions.get_from_id(claims["sub"])
     case user do
       nil -> {:error, "Unknown user"}
       _   -> {:ok, user}

--- a/lib/plenario2_auth/user_actions.ex
+++ b/lib/plenario2_auth/user_actions.ex
@@ -35,6 +35,35 @@ defmodule Plenario2Auth.UserActions do
   ##
   # edit
 
+  def update_name(user, new_name) do
+    UserChangesets.update_name(user, %{name: new_name})
+    |> Repo.update()
+  end
+
+  def update_email_address(user, new_email) do
+    UserChangesets.update_email_address(user, %{email_address: new_email})
+    |> Repo.update()
+  end
+
+  def update_org_info(user, opts \\ []) do
+    defaults = [
+      organization: :unchanged,
+      org_role: :unchanged
+    ]
+    options = Keyword.merge(defaults, opts) |> Enum.into(%{})
+    params =
+      Enum.filter(options, fn {_, value} -> value != :unchanged end)
+      |> Enum.into(%{})
+
+    UserChangesets.update_org_info(user, params)
+    |> Repo.update()
+  end
+
+  def update_password(user, new_password) do
+    UserChangesets.update_password(user, %{plaintext_password: new_password})
+    |> Repo.update()
+  end
+
   def promote_to_admin(user) do
     UserChangesets.update_admin(user, %{is_admin: true, is_trusted: true})
     |> Repo.update()

--- a/lib/plenario2_auth/user_changesets.ex
+++ b/lib/plenario2_auth/user_changesets.ex
@@ -22,30 +22,30 @@ defmodule Plenario2Auth.UserChangesets do
     |> hash_password()
   end
 
-  # def update_name(user, params) do
-  #   user
-  #   |> cast(params, [:name])
-  # end
-  #
-  # def update_email_address(user, params) do
-  #   user
-  #   |> cast(params, [:email_address])
-  #   |> validate_required([:email_address])
-  #   |> unique_constraint(:email_address)
-  #   |> validate_format(:email_address, @email_regex)
-  # end
-  #
-  # def update_password(user, params) do
-  #   user
-  #   |> cast(params, [:plaintext_password])
-  #   |> validate_required([:plaintext_password])
-  #   |> hash_password(params.plaintext_password)
-  # end
-  #
-  # def update_org_info(user, params) do
-  #   user
-  #   |> cast(params, [:organization, :org_role])
-  # end
+  def update_name(user, params) do
+    user
+    |> cast(params, [:name])
+  end
+
+  def update_email_address(user, params) do
+    user
+    |> cast(params, [:email_address])
+    |> validate_required([:email_address])
+    |> unique_constraint(:email_address)
+    |> validate_format(:email_address, @email_regex)
+  end
+
+  def update_password(user, params) do
+    user
+    |> cast(params, [:plaintext_password])
+    |> validate_required([:plaintext_password])
+    |> hash_password()
+  end
+
+  def update_org_info(user, params) do
+    user
+    |> cast(params, [:organization, :org_role])
+  end
 
   def update_active(user, params) do
     user

--- a/lib/plenario2_web/controllers/meta_controller.ex
+++ b/lib/plenario2_web/controllers/meta_controller.ex
@@ -59,7 +59,6 @@ defmodule Plenario2Web.MetaController do
 
   defp create_reply({:ok, meta}, conn) do
     conn
-    |> put_status(:created)
     |> put_flash(:success, "#{meta.name} Created!")
     |> redirect(to: meta_path(conn, :list))
   end

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -116,4 +116,34 @@ defmodule Plenario2Web.UserController do
     |> put_status(:bad_request)
     |> render("update_org_info.html", changeset: changeset, action: action)
   end
+
+  def get_update_password(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+    changeset = UserChangesets.update_password(user, %{})
+    action = user_path(conn, :do_update_password)
+
+    render(conn, "update_password.html", changeset: changeset, action: action)
+  end
+
+  def do_update_password(conn, %{"user" => %{"plaintext_password" => password}}) do
+    user = Guardian.Plug.current_resource(conn)
+
+    UserActions.update_password(user, password)
+    |> update_password_reply(conn)
+  end
+
+  defp update_password_reply({:ok, _}, conn) do
+    conn
+    |> put_flash(:success, "Your password has been updated")
+    |> redirect(to: user_path(conn, :index))
+  end
+
+  defp update_password_reply({:error, changeset}, conn) do
+    action = user_path(conn, :do_update_password)
+
+    conn
+    |> put_flash(:error, "Please review and fix errors below")
+    |> put_status(:bad_request)
+    |> render("update_password.html", changeset: changeset, action: action)
+  end
 end

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -1,0 +1,29 @@
+defmodule Plenario2Web.UserController do
+  use Plenario2Web, :controller
+
+  alias Plenario2.Actions.{MetaActions, AdminUserNoteActions}
+  alias Plenario2.Repo
+
+  def index(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+
+    unread_notes = AdminUserNoteActions.list([unread: true, for_user: user])
+    archived_notes = AdminUserNoteActions.list([acknowledged: true, for_user: user, oldest_first: true])
+
+    new = MetaActions.list([for_user: user, new: true])
+    awaiting = MetaActions.list([for_user: user, needs_approval: true])
+    ready = MetaActions.list([for_user: user, ready: true, limit_to: 3])
+    erred = MetaActions.list([for_user: user, erred: true])
+
+    conn
+    |> render(
+      "index.html",
+      unread_notes: unread_notes,
+      archived_notes: archived_notes,
+      new_metas: new,
+      awaiting_metas: awaiting,
+      ready_metas: ready,
+      erred_metas: erred
+    )
+  end
+end

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -57,4 +57,34 @@ defmodule Plenario2Web.UserController do
     |> put_status(:bad_request)
     |> render("update_name.html", changeset: changeset, action: action)
   end
+
+  def get_update_email(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+    changeset = UserChangesets.update_email_address(user, %{})
+    action = user_path(conn, :do_update_email)
+
+    render(conn, "update_email.html", changeset: changeset, action: action)
+  end
+
+  def do_update_email(conn, %{"user" => %{"email_address" => email}}) do
+    user = Guardian.Plug.current_resource(conn)
+
+    UserActions.update_email_address(user, email)
+    |> update_email_reply(conn)
+  end
+
+  defp update_email_reply({:ok, user}, conn) do
+    conn
+    |> put_flash(:success, "Your email address has been updated")
+    |> redirect(to: auth_path(conn, :get_login))
+  end
+
+  defp update_email_reply({:error, changeset}, conn) do
+    action = user_path(conn, :do_update_email)
+
+    conn
+    |> put_flash(:error, "Please review and fix errors below")
+    |> put_status(:bad_request)
+    |> render("update_email.html", changeset: changeset, action: action)
+  end
 end

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -75,7 +75,7 @@ defmodule Plenario2Web.UserController do
   defp update_email_reply({:ok, _}, conn) do
     conn
     |> put_flash(:success, "Your email address has been updated")
-    |> redirect(to: auth_path(conn, :get_login))
+    |> redirect(to: user_path(conn, :index))
   end
 
   defp update_email_reply({:error, changeset}, conn) do

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -3,7 +3,6 @@ defmodule Plenario2Web.UserController do
 
   alias Plenario2.Actions.{MetaActions, AdminUserNoteActions}
   alias Plenario2Auth.{UserActions, UserChangesets}
-  alias Plenario2.Repo
 
   def index(conn, _) do
     user = Guardian.Plug.current_resource(conn)
@@ -43,7 +42,7 @@ defmodule Plenario2Web.UserController do
     |> update_name_reply(conn)
   end
 
-  defp update_name_reply({:ok, user}, conn) do
+  defp update_name_reply({:ok, _}, conn) do
     conn
     |> put_flash(:success, "Your name has been updated")
     |> redirect(to: user_path(conn, :index))
@@ -73,7 +72,7 @@ defmodule Plenario2Web.UserController do
     |> update_email_reply(conn)
   end
 
-  defp update_email_reply({:ok, user}, conn) do
+  defp update_email_reply({:ok, _}, conn) do
     conn
     |> put_flash(:success, "Your email address has been updated")
     |> redirect(to: auth_path(conn, :get_login))
@@ -86,5 +85,35 @@ defmodule Plenario2Web.UserController do
     |> put_flash(:error, "Please review and fix errors below")
     |> put_status(:bad_request)
     |> render("update_email.html", changeset: changeset, action: action)
+  end
+
+  def get_update_org_info(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+    changeset = UserChangesets.update_org_info(user, %{})
+    action = user_path(conn, :do_update_org_info)
+
+    render(conn, "update_org_info.html", changeset: changeset, action: action)
+  end
+
+  def do_update_org_info(conn, %{"user" => %{"organization" => org, "org_role" => role}}) do
+    user = Guardian.Plug.current_resource(conn)
+
+    UserActions.update_org_info(user, [organization: org, org_role: role])
+    |> update_org_info_reply(conn)
+  end
+
+  defp update_org_info_reply({:ok, _}, conn) do
+    conn
+    |> put_flash(:success, "Your organization information has been updated")
+    |> redirect(to: user_path(conn, :index))
+  end
+
+  defp update_org_info_reply({:error, changeset}, conn) do
+    action = user_path(conn, :do_update_org_info)
+
+    conn
+    |> put_flash(:error, "Please review and fix errors below")
+    |> put_status(:bad_request)
+    |> render("update_org_info.html", changeset: changeset, action: action)
   end
 end

--- a/lib/plenario2_web/controllers/user_controller.ex
+++ b/lib/plenario2_web/controllers/user_controller.ex
@@ -2,6 +2,7 @@ defmodule Plenario2Web.UserController do
   use Plenario2Web, :controller
 
   alias Plenario2.Actions.{MetaActions, AdminUserNoteActions}
+  alias Plenario2Auth.{UserActions, UserChangesets}
   alias Plenario2.Repo
 
   def index(conn, _) do
@@ -25,5 +26,35 @@ defmodule Plenario2Web.UserController do
       ready_metas: ready,
       erred_metas: erred
     )
+  end
+
+  def get_update_name(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+    changeset = UserChangesets.update_name(user, %{})
+    action = user_path(conn, :do_update_name)
+
+    render(conn, "update_name.html", changeset: changeset, action: action)
+  end
+
+  def do_update_name(conn, %{"user" => %{"name" => name}}) do
+    user = Guardian.Plug.current_resource(conn)
+
+    UserActions.update_name(user, name)
+    |> update_name_reply(conn)
+  end
+
+  defp update_name_reply({:ok, user}, conn) do
+    conn
+    |> put_flash(:success, "Your name has been updated")
+    |> redirect(to: user_path(conn, :index))
+  end
+
+  defp update_name_reply({:error, changeset}, conn) do
+    action = user_path(conn, :do_update_name)
+
+    conn
+    |> put_flash(:error, "Please review and fix errors below")
+    |> put_status(:bad_request)
+    |> render("update_name.html", changeset: changeset, action: action)
   end
 end

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -66,6 +66,8 @@ defmodule Plenario2Web.Router do
     post "/notes/:id/acknowledge", AdminUserNoteController, :acknowledge
 
     get "/my/info", UserController, :index
+    get "/my/name", UserController, :get_update_name
+    put "/my/name", UserController, :do_update_name
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -70,6 +70,8 @@ defmodule Plenario2Web.Router do
     put "/my/name", UserController, :do_update_name
     get "/my/email", UserController, :get_update_email
     put "/my/email", UserController, :do_update_email
+    get "/my/org-info", UserController, :get_update_org_info
+    put "/my/org-info", UserController, :do_update_org_info
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -64,6 +64,8 @@ defmodule Plenario2Web.Router do
     post "/data-sets/:slug/submit-for-approval", MetaController, :submit_for_approval
 
     post "/notes/:id/acknowledge", AdminUserNoteController, :acknowledge
+
+    get "/my/info", UserController, :index
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -68,6 +68,8 @@ defmodule Plenario2Web.Router do
     get "/my/info", UserController, :index
     get "/my/name", UserController, :get_update_name
     put "/my/name", UserController, :do_update_name
+    get "/my/email", UserController, :get_update_email
+    put "/my/email", UserController, :do_update_email
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/router.ex
+++ b/lib/plenario2_web/router.ex
@@ -72,6 +72,8 @@ defmodule Plenario2Web.Router do
     put "/my/email", UserController, :do_update_email
     get "/my/org-info", UserController, :get_update_org_info
     put "/my/org-info", UserController, :do_update_org_info
+    get "/my/password", UserController, :get_update_password
+    put "/my/password", UserController, :do_update_password
   end
 
   scope "/admin", Plenario2Web do

--- a/lib/plenario2_web/template_helpers.ex
+++ b/lib/plenario2_web/template_helpers.ex
@@ -1,0 +1,23 @@
+defmodule Plenario2Web.TemplateHelpers do
+
+  def s_plural(word, length_) do
+    case length_ do
+      1 -> word
+      _ -> word <> "s"
+    end
+  end
+
+  def es_plural(word, length_) do
+    case length_ do
+      1 -> word
+      _ -> word <> "es"
+    end
+  end
+
+  def irregular_plural(singular, plural, length_) do
+    case length_ do
+      1 -> singular
+      _ -> plural
+    end
+  end
+end

--- a/lib/plenario2_web/templates/layout/app.html.eex
+++ b/lib/plenario2_web/templates/layout/app.html.eex
@@ -9,6 +9,23 @@
 
     <title>Plenario</title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <style>
+    @media (min-width: 900px) {
+      .container {
+        max-width: 870px;
+      }
+    }
+    @media (min-width: 1150px) {
+      .container {
+        max-width: 1120px;
+      }
+    }
+    @media (min-width: 1400px) {
+      .container {
+        max-width: 1370px;
+      }
+    }
+    </style>
   </head>
 
   <body>
@@ -20,7 +37,7 @@
               <li><%= link "Sign In", to: auth_path(@conn, :get_login), method: :get %></li>
               <li><%= link "Sign Up", to: auth_path(@conn, :get_register), method: :get %><li>
             <% else %>
-              <li><a>Hi, <%= @current_user.name %>!</a></li>
+              <li><%= link "Hi, #{@current_user.name}!", to: user_path(@conn, :index) %></li>
               <%= if @current_user.is_admin do %>
                 <li><%= link "Admin", to: admin_path(@conn, :index) %></li>
               <% end %>

--- a/lib/plenario2_web/templates/user/index.html.eex
+++ b/lib/plenario2_web/templates/user/index.html.eex
@@ -1,0 +1,201 @@
+<div class="row">
+  <div class="col-md-8">
+    <div class="jumbotron">
+
+      <div class="row">
+        <div class="col-md-6">
+          <%= link raw("<button class='btn btn-primary'>Create a New Data Set</button>"), to: meta_path(@conn, :get_create) %>
+        </div>
+        <div class="col-md-6">
+          <%= link raw("<button class='btn btn-primary'>View all My Data Sets</button>"), to: meta_path(@conn, :get_create) %>
+        </div>
+      </div>
+
+      <hr>
+
+      <% len_err = length(@erred_metas) %>
+      <%= if len_err > 0 do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h2><%= len_err %> Erred Data <%= s_plural("Set", len_err) %></h2>
+        </div>
+      </div>
+      <%= for m <- @erred_metas do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h3><%= m.name %></h3>
+        </div>
+      </div>
+      <% end %>
+      <hr>
+      <% end %>
+
+      <% len_wait =  length(@awaiting_metas) %>
+      <%= if len_wait > 0 do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h2><%= len_wait %> Data <%= s_plural("Set", len_wait) %> Awaiting Approval</h2>
+        </div>
+      </div>
+      <%= for m <- @awaiting_metas do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h3><%= m.name %></h3>
+        </div>
+      </div>
+      <% end %>
+      <hr>
+      <% end %>
+
+      <% len_new = length(@new_metas) %>
+      <%= if len_new > 0 do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h2><%= len_new %> Incomplete Data <%= s_plural("Set", len_new) %></h2>
+        </div>
+      </div>
+      <%= for m <- @new_metas do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h3><%= m.name %></h3>
+          <%= link "View Details and Edit", to: meta_path(@conn, :detail, m.slug) %>
+          <p><%= m.description %></p>
+        </div>
+      </div>
+      <% end %>
+      <hr>
+      <% end %>
+
+      <% len_ready = length(@ready_metas) %>
+      <%= if len_ready > 0 do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h2><%= len_ready %> Live Data <%= s_plural("Set", len_ready) %></h2>
+        </div>
+      </div>
+      <%= for m <- @ready_metas do %>
+      <div class="row">
+        <div class="col-md-12" style="text-align:left;">
+          <h3><%= m.name %></h3>
+          <%= link "View Details and Edit", to: meta_path(@conn, :detail, m.slug) %>
+          <p><%= m.description %></p>
+        </div>
+      </div>
+      <% end %>
+      <% end %>
+
+    </div>
+  </div>
+
+  <div class="col-md-4">
+
+    <div class="row">
+      <div class="col-md-12">
+        <h3>Personal Info<hr></h3>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-8">
+        <strong>Name:</strong><br>
+        <%= @current_user.name %>
+      </div>
+      <div class="col-md-4">
+        <a>Update Name</a>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-md-8">
+        <strong>Email:</strong><br>
+        <%= @current_user.email_address %>
+      </div>
+      <div class="col-md-4">
+        <a>Update Email</a>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-md-8">
+        <strong>Organization:</strong><br>
+        <%= @current_user.organization || "-" %>
+      </div>
+      <div class="col-md-4">
+        <a>Update Org Info</a>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-8">
+        <strong>Role:</strong><br>
+        <%= @current_user.org_role || "-" %>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="row">
+      <div class="col-md-12">
+        <a>Update Password</a>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-md-12">
+        <h3>Messages<hr></h3>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <h4>Unread</h4>
+      </div>
+    </div>
+
+    <%= if length(@unread_notes) > 0 do %>
+
+      <%= for note <- @unread_notes do %>
+        <div class="row">
+          <div class="col-md-12">
+            <p>
+              <strong><%= note.inserted_at %></strong><br>
+              <%= note.note %><br>
+              <%= note.acknowledged %>
+            </p>
+          </div>
+        </div>
+      <% end %>
+
+    <% else %>
+      <div class="row">
+        <div class="col-md-12">
+          <p>All caught up!</p>
+        </div>
+      </div>
+
+    <% end %>
+
+    <div class="row">
+      <div class="col-md-12">
+        <h4>Archived</h4>
+      </div>
+    </div>
+
+    <%= for note <- @archived_notes do %>
+      <div class="row">
+        <div class="col-md-12">
+          <p>
+            <strong><%= note.inserted_at %></strong><br>
+            <%= note.note %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/lib/plenario2_web/templates/user/index.html.eex
+++ b/lib/plenario2_web/templates/user/index.html.eex
@@ -139,7 +139,7 @@
 
     <div class="row">
       <div class="col-md-12">
-        <a>Update Password</a>
+        <%= link "Update Password", to: user_path(@conn, :get_update_password) %>
       </div>
     </div>
 

--- a/lib/plenario2_web/templates/user/index.html.eex
+++ b/lib/plenario2_web/templates/user/index.html.eex
@@ -125,7 +125,7 @@
         <%= @current_user.organization || "-" %>
       </div>
       <div class="col-md-4">
-        <a>Update Org Info</a>
+        <%= link "Update Org Info", to: user_path(@conn, :get_update_org_info) %>
       </div>
     </div>
     <div class="row">

--- a/lib/plenario2_web/templates/user/index.html.eex
+++ b/lib/plenario2_web/templates/user/index.html.eex
@@ -113,7 +113,7 @@
         <%= @current_user.email_address %>
       </div>
       <div class="col-md-4">
-        <a>Update Email</a>
+        <%= link "Update Email", to: user_path(@conn, :get_update_email) %>
       </div>
     </div>
 

--- a/lib/plenario2_web/templates/user/index.html.eex
+++ b/lib/plenario2_web/templates/user/index.html.eex
@@ -101,7 +101,7 @@
         <%= @current_user.name %>
       </div>
       <div class="col-md-4">
-        <a>Update Name</a>
+        <%= link "Update Name", to: user_path(@conn, :get_update_name) %>
       </div>
     </div>
 

--- a/lib/plenario2_web/templates/user/update_email.html.eex
+++ b/lib/plenario2_web/templates/user/update_email.html.eex
@@ -1,0 +1,26 @@
+<div class="row">
+  <h2>Update Your Email Address</h2>
+</div>
+
+<div class="row">
+  <strong>Warning:</strong> this will log you out and you will need to sign in
+  with your new email address.
+</div>
+
+<%= form_for @changeset, @action, fn f -> %>
+
+  <div class="row">
+    <div class="form-group">
+      <%= label f, :email_address, class: "control-label" %>
+      <%= text_input f, :email_address, class: "form-control" %>
+      <%= error_tag f, :email_address %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group">
+      <%= submit "Update", class: "btn btn-primary" %>
+    </div>
+  </div>
+
+<% end %>

--- a/lib/plenario2_web/templates/user/update_email.html.eex
+++ b/lib/plenario2_web/templates/user/update_email.html.eex
@@ -2,11 +2,6 @@
   <h2>Update Your Email Address</h2>
 </div>
 
-<div class="row">
-  <strong>Warning:</strong> this will log you out and you will need to sign in
-  with your new email address.
-</div>
-
 <%= form_for @changeset, @action, fn f -> %>
 
   <div class="row">

--- a/lib/plenario2_web/templates/user/update_name.html.eex
+++ b/lib/plenario2_web/templates/user/update_name.html.eex
@@ -1,0 +1,21 @@
+<div class="row">
+  <h2>Update Your Name</h2>
+</div>
+
+<%= form_for @changeset, @action, fn f -> %>
+
+  <div class="row">
+    <div class="form-group">
+      <%= label f, :name, class: "control-label" %>
+      <%= text_input f, :name, class: "form-control" %>
+      <%= error_tag f, :name %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group">
+      <%= submit "Update", class: "btn btn-primary" %>
+    </div>
+  </div>
+
+<% end %>

--- a/lib/plenario2_web/templates/user/update_org_info.html.eex
+++ b/lib/plenario2_web/templates/user/update_org_info.html.eex
@@ -1,0 +1,29 @@
+<div class="row">
+  <h2>Update Your Organization Info</h2>
+</div>
+
+<%= form_for @changeset, @action, fn f -> %>
+
+  <div class="row">
+    <div class="form-group">
+      <%= label f, :organization, class: "control-label" %>
+      <%= text_input f, :organization, class: "form-control" %>
+      <%= error_tag f, :organization %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group">
+      <%= label f, "Role", class: "control-label" %>
+      <%= text_input f, :org_role, class: "form-control" %>
+      <%= error_tag f, :org_role %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group">
+      <%= submit "Update", class: "btn btn-primary" %>
+    </div>
+  </div>
+
+<% end %>

--- a/lib/plenario2_web/templates/user/update_password.html.eex
+++ b/lib/plenario2_web/templates/user/update_password.html.eex
@@ -1,0 +1,21 @@
+<div class="row">
+  <h2>Update Your Password</h2>
+</div>
+
+<%= form_for @changeset, @action, fn f -> %>
+
+  <div class="row">
+    <div class="form-group">
+      <%= label f, "Password", class: "control-label" %>
+      <%= password_input f, :plaintext_password, class: "form-control" %>
+      <%= error_tag f, :plaintext_password %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group">
+      <%= submit "Update", class: "btn btn-primary" %>
+    </div>
+  </div>
+
+<% end %>

--- a/lib/plenario2_web/views/user_view.ex
+++ b/lib/plenario2_web/views/user_view.ex
@@ -1,0 +1,4 @@
+defmodule Plenario2Web.UserView do
+  use Plenario2Web, :view
+  import Plenario2Web.TemplateHelpers
+end

--- a/test/plenario2_web/controllers/meta_controller_test.exs
+++ b/test/plenario2_web/controllers/meta_controller_test.exs
@@ -33,7 +33,7 @@ defmodule Plenario2Web.MetaControllerTest do
       assert length(MetaActions.list()) == 0
 
       conn = post(conn, meta_path(conn, :do_create), %{"meta" => %{"name" => "Test Data", "source_url" => "https://example.com/test-data"}})
-      assert "/data-sets/list" = redir_path = redirected_to(conn, :created)
+      assert "/data-sets/list" = redir_path = redirected_to(conn, :found)
       conn = get(recycle(conn), redir_path)
       response = html_response(conn, :ok)
 

--- a/test/plenario2_web/controllers/user_controller_test.exs
+++ b/test/plenario2_web/controllers/user_controller_test.exs
@@ -1,0 +1,22 @@
+defmodule Plenario2Web.UserControllerTest do
+  use Plenario2Web.ConnCase, async: true
+  alias Plenario2.Actions.MetaActions
+  alias Plenario2Auth.UserActions
+
+  describe ":index" do
+    test "as anonymous", %{conn: conn} do
+      conn
+      |> get(user_path(conn, :index))
+      |> response(:unauthorized)
+    end
+
+    test "as a logged in user", %{conn: conn} do
+      {:ok, user} = UserActions.create("test", "password", "test@example.com")
+      conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+      conn
+      |> get(user_path(conn, :index))
+      |> html_response(:ok)
+    end
+  end
+end

--- a/test/plenario2_web/controllers/user_controller_test.exs
+++ b/test/plenario2_web/controllers/user_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule Plenario2Web.UserControllerTest do
   use Plenario2Web.ConnCase, async: true
-  alias Plenario2.Actions.MetaActions
   alias Plenario2Auth.UserActions
 
   describe ":index" do
@@ -11,12 +10,35 @@ defmodule Plenario2Web.UserControllerTest do
     end
 
     test "as a logged in user", %{conn: conn} do
-      {:ok, user} = UserActions.create("test", "password", "test@example.com")
+      UserActions.create("test", "password", "test@example.com")
       conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
 
       conn
       |> get(user_path(conn, :index))
       |> html_response(:ok)
     end
+  end
+
+  test ":get_update_name", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    res = conn
+      |> get(user_path(conn, :get_update_name))
+      |> html_response(:ok)
+
+    assert res =~ "Update Your Name"
+  end
+
+  test ":do_update_name", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    conn
+    |> put(user_path(conn, :do_update_name, %{"user" => %{"name" => "My New Name"}}))
+    |> html_response(:found)
+
+    user = UserActions.get_from_email("test@example.com")
+    assert user.name == "My New Name"
   end
 end

--- a/test/plenario2_web/controllers/user_controller_test.exs
+++ b/test/plenario2_web/controllers/user_controller_test.exs
@@ -101,4 +101,37 @@ defmodule Plenario2Web.UserControllerTest do
     assert user.organization == "University of Chicago"
     assert user.org_role == "Internet Janitor"
   end
+
+  test ":get_update_password", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    res = conn
+      |> get(user_path(conn, :get_update_password))
+      |> html_response(:ok)
+
+    assert res =~ "Update Your Password"
+  end
+
+  describe ":do_update_password" do
+    test "with a good password", %{conn: conn} do
+      UserActions.create("test", "password", "test@example.com")
+      conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+      conn
+      |> put(user_path(conn, :do_update_password, %{"user" => %{"plaintext_password" => "shh secret"}}))
+      |> html_response(:found)
+
+      post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test2@example.com", "plaintext_password" => "shh secret"}}))
+    end
+
+    test "with a bad password", %{conn: conn} do
+      UserActions.create("test", "password", "test@example.com")
+      conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+      conn
+      |> put(user_path(conn, :do_update_password, %{"user" => %{"plaintext_password" => ""}}))
+      |> html_response(:bad_request)
+    end
+  end
 end

--- a/test/plenario2_web/controllers/user_controller_test.exs
+++ b/test/plenario2_web/controllers/user_controller_test.exs
@@ -77,4 +77,28 @@ defmodule Plenario2Web.UserControllerTest do
       |> html_response(:bad_request)
     end
   end
+
+  test ":get_update_org_info", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    res = conn
+      |> get(user_path(conn, :get_update_org_info))
+      |> html_response(:ok)
+
+    assert res =~ "Update Your Organization Info"
+  end
+
+  test ":do_update_org_info", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    conn
+    |> put(user_path(conn, :do_update_org_info, %{"user" => %{"organization" => "University of Chicago", "org_role" => "Internet Janitor"}}))
+    |> html_response(:found)
+
+    user = UserActions.get_from_email("test@example.com")
+    assert user.organization == "University of Chicago"
+    assert user.org_role == "Internet Janitor"
+  end
 end

--- a/test/plenario2_web/controllers/user_controller_test.exs
+++ b/test/plenario2_web/controllers/user_controller_test.exs
@@ -41,4 +41,40 @@ defmodule Plenario2Web.UserControllerTest do
     user = UserActions.get_from_email("test@example.com")
     assert user.name == "My New Name"
   end
+
+  test ":get_update_email", %{conn: conn} do
+    UserActions.create("test", "password", "test@example.com")
+    conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+    res = conn
+      |> get(user_path(conn, :get_update_email))
+      |> html_response(:ok)
+
+    assert res =~ "Update Your Email Address"
+  end
+
+  describe ":do_update_email" do
+    test "with a good email address", %{conn: conn} do
+      UserActions.create("test", "password", "test@example.com")
+      conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+      conn
+      |> put(user_path(conn, :do_update_email, %{"user" => %{"email_address" => "test2@example.com"}}))
+      |> html_response(:found)
+
+      user = UserActions.get_from_email("test2@example.com")
+      assert user.name == "test"
+
+      post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test2@example.com", "plaintext_password" => "password"}}))
+    end
+
+    test "with a bad email address", %{conn: conn} do
+      UserActions.create("test", "password", "test@example.com")
+      conn = post(conn, auth_path(conn, :do_login, %{"user" => %{"email_address" => "test@example.com", "plaintext_password" => "password"}}))
+
+      conn
+      |> put(user_path(conn, :do_update_email, %{"user" => %{"email_address" => "i'm not giving my email to a machine"}}))
+      |> html_response(:bad_request)
+    end
+  end
 end

--- a/test/plenario2_web/template_helpers_test.exs
+++ b/test/plenario2_web/template_helpers_test.exs
@@ -1,0 +1,38 @@
+defmodule Plenario2Web.TemplateHelpersTest do
+  use ExUnit.Case, asnc: true
+
+  import Plenario2Web.TemplateHelpers
+
+  describe ":s_plural" do
+    test "with 1" do
+      assert s_plural("Data Set", 1) == "Data Set"
+    end
+
+    test "with not 1" do
+      assert s_plural("Data Set", 2) == "Data Sets"
+      assert s_plural("Data Set", 0) == "Data Sets"
+    end
+  end
+
+  describe ":es_plural" do
+    test "with 1" do
+      assert es_plural("Crash", 1) == "Crash"
+    end
+
+    test "with not 1" do
+      assert es_plural("Crash", 2) == "Crashes"
+      assert es_plural("Crash", 0) == "Crashes"
+    end
+  end
+
+  describe ":irregular_plural" do
+    test "with 1" do
+      assert irregular_plural("Man", "Men", 1) == "Man"
+    end
+
+    test "with not 1" do
+      assert irregular_plural("Woman", "Women", 2) == "Women"
+      assert irregular_plural("Woman", "Women", 0) == "Women"
+    end
+  end
+end


### PR DESCRIPTION
users can change:

- name
- email address
- password
- org info

i also fixed a stupid mistake i made in guardian pinning user resources to the email address rather than their id.

closes #22