### PR TITLE
Json etl

### DIFF
--- a/lib/plenario2_etl/templates/upsert.sql.eex
+++ b/lib/plenario2_etl/templates/upsert.sql.eex
@@ -3,7 +3,7 @@
 -- columns          list[charlist]
 -- table            charlist
 -- constraints      list[charlist]
--- pks              list
+
 
 <% last_index = Enum.count(rows) - 1 %>
 
@@ -33,4 +33,4 @@ ON CONFLICT ("<%= Enum.join(constraints, ~s{","}) %>")
     <%= if index != Enum.count(constraints) - 1 do %>,<% end %>
   <% end %>
   RETURNING 
-    t.*
+    t."<%= Enum.join(columns, ~s{", t."}) %>"


### PR DESCRIPTION
#### Notes

- ETL Pipeline now adapts ingest strategy based on `meta.source_type`
- ETL Pipeline can ingest and diff json data

#### Notes

The worker has some repeated code, especially between `load_csv` and `load_json`. Rows are always represented as keyword lists, the only difference is the decoder that generates them. There's plenty of room for refactoring in later PRs. 