### PR TITLE
Made Meta Refresh Rates Standardized

### DIFF
--- a/lib/plenario2/changesets/meta_changesets.ex
+++ b/lib/plenario2/changesets/meta_changesets.ex
@@ -160,7 +160,7 @@ defmodule Plenario2.Changesets.MetaChangesets do
   defp validate_refresh_rate(changeset) do
     rr = get_field(changeset, :refresh_rate)
 
-    if Enum.member?([nil, "minutes", "hours", "days", "weeks", "months", "years"], rr) do
+    if Enum.member?(Meta.get_refresh_rate_values(), rr) do
       changeset
     else
       changeset |> add_error(:refresh_rate, "Invalid value `#{rr}`")

--- a/lib/plenario2/schemas/meta.ex
+++ b/lib/plenario2/schemas/meta.ex
@@ -58,4 +58,28 @@ defmodule Plenario2.Schemas.Meta do
     has_many(:export_jobs, Plenario2.Schemas.ExportJob)
     has_many(:admin_user_notes, Plenario2.Schemas.AdminUserNote)
   end
+
+  @refresh_rate_values [
+    nil,
+    "minutes",
+    "hours",
+    "days",
+    "weeks",
+    "months",
+    "years"
+  ]
+
+  @refresh_rate_choices [
+    "Don't Refresh": nil,
+    "Minutes": "minutes",
+    "Hours": "hours",
+    "Days": "days",
+    "Weeks": "weeks",
+    "Months": "months",
+    "Years": "years"
+  ]
+
+  def get_refresh_rate_values(), do: @refresh_rate_values
+
+  def get_refresh_rate_choices(), do: @refresh_rate_choices
 end

--- a/lib/plenario2_web/controllers/meta_controller.ex
+++ b/lib/plenario2_web/controllers/meta_controller.ex
@@ -184,8 +184,9 @@ defmodule Plenario2Web.MetaController do
     meta = MetaActions.get(slug, [with_user: true])
     changeset = MetaChangesets.update_refresh_info(meta, %{})
     action = meta_path(conn, :do_update_refresh_info, slug)
+    rr_choices = Meta.get_refresh_rate_choices()
 
-    render(conn, "update_refresh_info.html", changeset: changeset, action: action)
+    render(conn, "update_refresh_info.html", changeset: changeset, action: action, rr_choices: rr_choices)
   end
 
   def do_update_refresh_info(conn, %{"slug" => slug, "meta" => %{"refresh_rate" => refresh_rate, "refresh_interval" => refresh_interval, "refresh_starts_on" => refresh_starts_on, "refresh_ends_on" => refresh_ends_on}}) do

--- a/lib/plenario2_web/templates/meta/update_refresh_info.html.eex
+++ b/lib/plenario2_web/templates/meta/update_refresh_info.html.eex
@@ -4,7 +4,7 @@
 
   <div class="form-group">
     <%= label f, :refresh_rate, class: "control-label" %>
-    <%= select f, :refresh_rate, ["Don't Refresh": nil, "Minutes": "minutes", "Hours": "hours", "Days": "days", "Weeks": "weeks", "Months": "months", "Years": "years"], class: "form-control" %>
+    <%= select f, :refresh_rate, @rr_choices, class: "form-control" %>
     <%= error_tag f, :refresh_rate %>
   </div>
 


### PR DESCRIPTION
we kinda had these floating around and it made sense to standardize them
on the schema and expose them as _get_ functions.

fixes #95