### PR TITLE
Removed DataSetField `make_primary_key` Functionality

### DIFF
--- a/lib/plenario2/actions/data_set_field_actions.ex
+++ b/lib/plenario2/actions/data_set_field_actions.ex
@@ -70,11 +70,6 @@ defmodule Plenario2.Actions.DataSetFieldActions do
     |> Repo.update()
   end
 
-  def make_primary_key(field) do
-    DataSetFieldChangesets.make_primary_key(field)
-    |> Repo.update()
-  end
-
   @doc """
   Deletes a given data set field
   """

--- a/lib/plenario2/changesets/data_set_field_changesets.ex
+++ b/lib/plenario2/changesets/data_set_field_changesets.ex
@@ -57,13 +57,6 @@ defmodule Plenario2.Changesets.DataSetFieldChangesets do
     |> validate_type()
   end
 
-  # TODO: delete this? i don't know where we're using it or why we would...
-  def make_primary_key(field) do
-    field
-    |> cast(%{}, [])
-    |> put_change(:opts, "not null primary key")
-  end
-
   # Converts name values to snake case
   # For example, if a user passes a field named "Event ID", this would return "event_id"
   defp check_name(changeset) do

--- a/test/plenario2/data_set_field_test.exs
+++ b/test/plenario2/data_set_field_test.exs
@@ -21,12 +21,6 @@ defmodule DataSetFieldTests do
     assert length(fields) == 2
   end
 
-  test "make a data set field a primary key", context do
-    {:ok, field} = DataSetFieldActions.create(context.meta.id, "location", "text")
-    {:ok, field} = DataSetFieldActions.make_primary_key(field)
-    assert field.opts == "not null primary key"
-  end
-
   test "delete a data set field", context do
     {:ok, field} = DataSetFieldActions.create(context.meta.id, "location", "text")
     DataSetFieldActions.delete(field)

--- a/test/plenario2_etl/worker_test.exs
+++ b/test/plenario2_etl/worker_test.exs
@@ -35,12 +35,11 @@ defmodule Plenario2Etl.WorkerTest do
   setup context do
     meta = context.meta
 
-    {:ok, user} = UserActions.create("Trusted User", "password", "trusted@example.com") 
-    {:ok, pk} = DataSetFieldActions.create(meta.id, "pk", "integer")
+    {:ok, user} = UserActions.create("Trusted User", "password", "trusted@example.com")
+    {:ok, _} = DataSetFieldActions.create(meta.id, "pk", "integer")
     DataSetFieldActions.create(meta.id, "datetime", "timestamptz")
     DataSetFieldActions.create(meta.id, "location", "text")
     DataSetFieldActions.create(meta.id, "data", "text")
-    DataSetFieldActions.make_primary_key(pk)
     {:ok, constraint} = DataSetConstraintActions.create(meta.id, ["pk"])
     {:ok, job} = EtlJobActions.create(meta.id)
     VirtualPointFieldActions.create_from_loc(meta.id, "location")


### PR DESCRIPTION
this is superfluous when we have unique constraints. PK is a nice
shortcut, but there isn't much benefit to this system having both
options: rather it might make it confusing for non-developer users.

fixes #98