### PR TITLE
Disallow field changes when meta ready

### DIFF
--- a/lib/plenario2/changesets/data_set_field_changesets.ex
+++ b/lib/plenario2/changesets/data_set_field_changesets.ex
@@ -6,6 +6,7 @@ defmodule Plenario2.Changesets.DataSetFieldChangesets do
 
   import Ecto.Changeset
 
+  alias Plenario2.Actions.MetaActions
   alias Plenario2.Schemas.DataSetField
 
   @typedoc """
@@ -55,6 +56,7 @@ defmodule Plenario2.Changesets.DataSetFieldChangesets do
     |> cast_assoc(:meta)
     |> check_name()
     |> validate_type()
+    |> check_meta_state()
   end
 
   # Converts name values to snake case
@@ -76,6 +78,20 @@ defmodule Plenario2.Changesets.DataSetFieldChangesets do
       changeset
     else
       changeset |> add_error(:type, "Invalid type selection")
+    end
+  end
+
+  # Disallow update after the related Meta is in ready state
+  defp check_meta_state(changeset) do
+    meta =
+      get_field(changeset, :meta_id)
+      |> MetaActions.get()
+
+    if meta.state == "ready" do
+      changeset
+      |> add_error(:name, "Cannot alter any fields after the parent data set has been approved. If you need to update this field, please contact the administrators.")
+    else
+      changeset
     end
   end
 end

--- a/lib/plenario2_web/controllers/data_set_field_controller.ex
+++ b/lib/plenario2_web/controllers/data_set_field_controller.ex
@@ -44,7 +44,15 @@ defmodule Plenario2Web.DataSetFieldController do
   def edit(conn, %{"slug"=> slug, "id" => id}) do
     field = Repo.get!(DataSetField, id)
     changeset = DataSetFieldChangesets.update(field)
-    render(conn, "edit.html", field: field, changeset: changeset, slug: slug, field_type_options: @field_type_options)
+
+    meta = MetaActions.get(field.meta_id)
+    disabled =
+      case meta.state == "ready" do
+        true -> "disabled"
+        false -> ""
+      end
+
+    render(conn, "edit.html", field: field, changeset: changeset, slug: slug, field_type_options: @field_type_options, disabled: disabled)
   end
 
   def update(conn, %{"slug" => slug, "id" => id, "data_set_field" => field_params}) do

--- a/lib/plenario2_web/controllers/meta_controller.ex
+++ b/lib/plenario2_web/controllers/meta_controller.ex
@@ -31,9 +31,16 @@ defmodule Plenario2Web.MetaController do
       nil -> false
       _   -> user.id == meta.user.id
     end
+
+    editing_disabled =
+      case meta.state == "ready" do
+        true -> "disable"
+        false -> ""
+      end
+
     case meta do
       nil  -> conn |> put_status(:not_found) |> put_view(ErrorView) |> render("404.html")
-      _    -> render(conn, "detail.html", meta: meta, owner: owner, curr_path: curr_path)
+      _    -> render(conn, "detail.html", meta: meta, owner: owner, curr_path: curr_path, editing_disabled: editing_disabled)
     end
   end
 

--- a/lib/plenario2_web/controllers/meta_controller.ex
+++ b/lib/plenario2_web/controllers/meta_controller.ex
@@ -32,15 +32,20 @@ defmodule Plenario2Web.MetaController do
       _   -> user.id == meta.user.id
     end
 
-    editing_disabled =
-      case meta.state == "ready" do
-        true -> "disable"
-        false -> ""
-      end
-
     case meta do
-      nil  -> conn |> put_status(:not_found) |> put_view(ErrorView) |> render("404.html")
-      _    -> render(conn, "detail.html", meta: meta, owner: owner, curr_path: curr_path, editing_disabled: editing_disabled)
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(ErrorView)
+        |> render("404.html")
+
+      _ ->
+        editing_disabled =
+          case meta.state == "ready" do
+            true -> "disable"
+            false -> ""
+          end
+        render(conn, "detail.html", meta: meta, owner: owner, curr_path: curr_path, editing_disabled: editing_disabled)
     end
   end
 

--- a/lib/plenario2_web/templates/data_set_field/edit.html.eex
+++ b/lib/plenario2_web/templates/data_set_field/edit.html.eex
@@ -1,25 +1,32 @@
 <h2>Update Data Set Field</h2>
 
+<%= if @disabled == "disabled" do %>
+<div>
+  <h4>The Data Set that this field belongs to is live, therefor this field
+    cannot be edited. If you need to make changes, please contant the admins.</h4>
+  </div>
+<% end %>
+
 <%= form_for @changeset, data_set_field_path(@conn, :update, @slug, @field.id), fn f -> %>
   <div class="form-group">
     <%= label f, "Field Name", class: "control-label" %>
-    <%= text_input f, :name, class: "form-control" %>
+    <%= text_input f, :name, class: "form-control", disabled: @disabled %>
     <%= error_tag f, :name %>
   </div>
 
   <div class="form-group">
     <%= label f, "Type", class: "control-label" %>
-    <%= select f, :type, @field_type_options, class: "form-control" %>
+    <%= select f, :type, @field_type_options, class: "form-control", disabled: @disabled %>
     <%= error_tag f, :type %>
   </div>
 
   <div class="form-group">
     <%= label f, "Modifiers", class: "control-label" %>
-    <%= text_input f, :opts, class: "form-control", value: "default null" %>
+    <%= text_input f, :opts, class: "form-control", value: "default null", disabled: @disabled %>
     <%= error_tag f, :opts %>
   </div>
 
   <div class="from-group">
-    <%= submit "Update", class: "btn btn-primary" %>
+    <%= submit "Update", class: "btn btn-primary", disabled: @disabled %>
   </div>
 <% end %>

--- a/lib/plenario2_web/templates/meta/detail.html.eex
+++ b/lib/plenario2_web/templates/meta/detail.html.eex
@@ -152,7 +152,13 @@ div.row { margin-bottom: 2em; }
     <td><%= psql_to_human(f.type) %></td>
     <td><%= f.opts %></td>
     <%= if @owner do %>
-      <td><%= link "Edit", to: data_set_field_path(@conn, :edit, @meta.slug, f.id), method: :get %></td>
+      <td>
+        <%= if @editing_disabled != "disable" do %>
+          <%= link "Edit", to: data_set_field_path(@conn, :edit, @meta.slug, f.id), method: :get %>
+        <% else %>
+          &nbsp;
+        <% end %>
+      </td>
     <% end %>
   </tr>
   <% end %>
@@ -160,7 +166,7 @@ div.row { margin-bottom: 2em; }
 
 <div class="row">
   <div class="col-md-12">
-    <%= link raw("<button class='btn btn-primary'>Add a New Field</button>"), to: data_set_field_path(@conn, :new, @meta.slug) %>
+    <%= button "Add a New Field", to: data_set_field_path(@conn, :new, @meta.slug), method: :get, class: "btn btn-primary", disabled: @editing_disabled %>
   </div>
 </div>
 
@@ -187,10 +193,10 @@ div.row { margin-bottom: 2em; }
 
 <div class="row">
   <div class="col-md-6">
-    <%= button "Add a New Location Field From a Single Text Field", to: virtual_point_field_path(@conn, :get_create_loc, @meta.slug), method: :get, class: "btn btn-primary" %>
+    <%= button "Add a New Location Field From a Single Text Field", to: virtual_point_field_path(@conn, :get_create_loc, @meta.slug), method: :get, class: "btn btn-primary", disabled: @editing_disabled %>
   </div>
   <div class="col-md-6">
-    <%= button "Add a New Location Field from a Long/Lat Field Combo", to: virtual_point_field_path(@conn, :get_create_longlat, @meta.slug), method: :get, class: "btn btn-primary pull-right" %>
+    <%= button "Add a New Location Field from a Long/Lat Field Combo", to: virtual_point_field_path(@conn, :get_create_longlat, @meta.slug), method: :get, class: "btn btn-primary pull-right", disabled: @editing_disabled %>
   </div>
 </div>
 
@@ -223,7 +229,7 @@ div.row { margin-bottom: 2em; }
 
 <div class="row">
   <div class="col-md-12">
-    <%= button "Add a New Date Field", to: virtual_date_field_path(@conn, :get_create, @meta.slug), method: :get, class: "btn btn-primary" %>
+    <%= button "Add a New Date Field", to: virtual_date_field_path(@conn, :get_create, @meta.slug), method: :get, class: "btn btn-primary", disabled: @editing_disabled %>
   </div>
 </div>
 
@@ -244,7 +250,7 @@ div.row { margin-bottom: 2em; }
 
 <div class="row">
   <div class="col-md-12">
-    <%= button "Add a New Constraint", to: data_set_constraint_path(@conn, :get_create, @meta.slug), method: :get, class: "btn btn-primary" %>
+    <%= button "Add a New Constraint", to: data_set_constraint_path(@conn, :get_create, @meta.slug), method: :get, class: "btn btn-primary", disabled: @editing_disabled %>
   </div>
 </div>
 

--- a/test/plenario2/data_set_field_test.exs
+++ b/test/plenario2/data_set_field_test.exs
@@ -1,7 +1,9 @@
 defmodule DataSetFieldTests do
   use Plenario2.DataCase, async: true
 
-  alias Plenario2.Actions.DataSetFieldActions
+  alias Plenario2.Actions.{DataSetFieldActions, MetaActions}
+
+  alias Plenario2Auth.UserActions
 
   test "create a data set field", context do
     {:ok, field} = DataSetFieldActions.create(context.meta.id, "location", "text")
@@ -26,5 +28,38 @@ defmodule DataSetFieldTests do
     DataSetFieldActions.delete(field)
 
     assert length(DataSetFieldActions.list_for_meta(context.meta)) == 0
+  end
+
+  describe "update the field" do
+    test "when the meta hasn't been approved yet", context do
+      {:ok, field} = DataSetFieldActions.create(context.meta, "event_id", "text")
+
+      {:ok, field} = DataSetFieldActions.update(field, %{type: "integer"})
+      assert field.type == "integer"
+    end
+
+    test "with a bad type", context do
+      {:ok, field} = DataSetFieldActions.create(context.meta, "event_id", "text")
+
+      {:error, error} = DataSetFieldActions.update(field, %{type: "barf"})
+      assert error.errors == [type: {"Invalid type selection", []}]
+    end
+
+    test "when the meta has already been approved", context do
+      {:ok, field} = DataSetFieldActions.create(context.meta, "event_id", "text")
+
+      UserActions.promote_to_admin(context.user)
+      user = UserActions.get_from_id(context.user.id)
+      meta = MetaActions.get(context.meta.id, [with_user: true])
+
+      MetaActions.submit_for_approval(meta)
+      meta = MetaActions.get(meta.id, [with_user: true])
+      MetaActions.approve(meta, user)
+      meta = MetaActions.get(meta.id, [with_user: true])
+      assert meta.state == "ready"
+
+      {:error, error} = DataSetFieldActions.update(field, %{type: "integer"})
+      assert error.errors == [name: {"Cannot alter any fields after the parent data set has been approved. If you need to update this field, please contact the administrators.", []}]
+    end
   end
 end


### PR DESCRIPTION
- added function to DataSetFieldChangesets to disallow updates when meta is ready
- disabled editing in DataSetFieldController when meta is ready
- disabled editing fields in MetaController when meta is ready
- disabled all _Add ..._ buttons in MetaController when meta is ready

i also opened issues to add updates/restrict updates for the other related fields.

closes #112 
closes #119 