### PR TITLE
Fixed Data Set Table Name Bug

### DIFF
--- a/lib/plenario2/actions/templates/add_constraint.sql.eex
+++ b/lib/plenario2/actions/templates/add_constraint.sql.eex
@@ -3,6 +3,6 @@ ALTER TABLE "<%= table_name %>"
   <% len_fields = length(field_names) %>
   (
     <%= for {f, i} <- Enum.with_index(field_names) do %>
-      <%= f %><%= if i+1 < len_fields do %>,<% end %>
+      "<%= f %>"<%= if i+1 < len_fields do %>,<% end %>
     <% end %>
   );

--- a/lib/plenario2/actions/templates/add_constraint.sql.eex
+++ b/lib/plenario2/actions/templates/add_constraint.sql.eex
@@ -1,4 +1,4 @@
-ALTER TABLE <%= table_name %>
+ALTER TABLE "<%= table_name %>"
   ADD CONSTRAINT <%= constraint_name %> UNIQUE
   <% len_fields = length(field_names) %>
   (

--- a/lib/plenario2/actions/templates/add_constraint.sql.eex
+++ b/lib/plenario2/actions/templates/add_constraint.sql.eex
@@ -1,5 +1,5 @@
 ALTER TABLE "<%= table_name %>"
-  ADD CONSTRAINT <%= constraint_name %> UNIQUE
+  ADD CONSTRAINT "<%= constraint_name %>" UNIQUE
   <% len_fields = length(field_names) %>
   (
     <%= for {f, i} <- Enum.with_index(field_names) do %>

--- a/lib/plenario2/actions/templates/create_point_trigger_function.sql.eex
+++ b/lib/plenario2/actions/templates/create_point_trigger_function.sql.eex
@@ -1,5 +1,5 @@
 CREATE FUNCTION
-  <%= function_name %>()
+  "<%= function_name %>"()
 RETURNS TRIGGER AS $$
 
   BEGIN

--- a/lib/plenario2/actions/templates/create_point_trigger_function.sql.eex
+++ b/lib/plenario2/actions/templates/create_point_trigger_function.sql.eex
@@ -5,9 +5,9 @@ RETURNS TRIGGER AS $$
   BEGIN
     <%= for f <- fields do %>
     <%= if f.location_field do %>
-    new.<%= f.name %> := parse_pt_location_<%= srid %>(new.<%= f.location_field %>);
+    new."<%= f.name %>" := parse_pt_location_<%= srid %>(new."<%= f.location_field %>");
     <% else %>
-    new.<%= f.name %> := parse_pt_long_lat_<%= srid %>(new.<%= f.longitude_field %>, new.<%= f.latitude_field %>);
+    new."<%= f.name %>" := parse_pt_long_lat_<%= srid %>(new."<%= f.longitude_field %>", new."<%= f.latitude_field %>");
     <% end %>
     <% end %>
     return new;

--- a/lib/plenario2/actions/templates/create_table.sql.eex
+++ b/lib/plenario2/actions/templates/create_table.sql.eex
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS "<%= table_name %>" (
   <% len_fields = length(fields) %>
   <%= for {f, i} <- Enum.with_index(fields) do %>
-  <%= f.name %> <%= f.type %> <%= f.opts %> <%= if i+1 < len_fields do %>,<% end %>
+  "<%= f.name %>" <%= f.type %> <%= f.opts %> <%= if i+1 < len_fields do %>,<% end %>
   <% end %>
 );

--- a/lib/plenario2/actions/templates/create_table.sql.eex
+++ b/lib/plenario2/actions/templates/create_table.sql.eex
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS <%= table_name %> (
+CREATE TABLE IF NOT EXISTS "<%= table_name %>" (
   <% len_fields = length(fields) %>
   <%= for {f, i} <- Enum.with_index(fields) do %>
   <%= f.name %> <%= f.type %> <%= f.opts %> <%= if i+1 < len_fields do %>,<% end %>

--- a/lib/plenario2/actions/templates/create_timestamp_trigger_function.sql.eex
+++ b/lib/plenario2/actions/templates/create_timestamp_trigger_function.sql.eex
@@ -1,5 +1,5 @@
 CREATE FUNCTION
-  <%= function_name %>()
+  "<%= function_name %>"()
 RETURNS TRIGGER AS $$
 
   BEGIN

--- a/lib/plenario2/actions/templates/create_timestamp_trigger_function.sql.eex
+++ b/lib/plenario2/actions/templates/create_timestamp_trigger_function.sql.eex
@@ -4,13 +4,13 @@ RETURNS TRIGGER AS $$
 
   BEGIN
     <%= for f <- fields do %>
-    new.<%= f.name %> := parse_timestamp_<%= timezone %>(
-      new.<%= f.year_field %>,
-      <%= if f.month_field do %>new.<%= f.month_field %><% else %>NULL<% end %>,
-      <%= if f.day_field do %>new.<%= f.day_field %><% else %>NULL<% end %>,
-      <%= if f.hour_field do %>new.<%= f.hour_field %><% else %>NULL<% end %>,
-      <%= if f.minute_field do %>new.<%= f.minute_field %><% else %>NULL<% end %>,
-      <%= if f.second_field do %>new.<%= f.second_field %><% else %>NULL<% end %>
+    new."<%= f.name %>" := parse_timestamp_<%= timezone %>(
+      new."<%= f.year_field %>",
+      <%= if f.month_field do %>new."<%= f.month_field %>"<% else %>NULL<% end %>,
+      <%= if f.day_field do %>new."<%= f.day_field %>"<% else %>NULL<% end %>,
+      <%= if f.hour_field do %>new."<%= f.hour_field %>"<% else %>NULL<% end %>,
+      <%= if f.minute_field do %>new."<%= f.minute_field %>"<% else %>NULL<% end %>,
+      <%= if f.second_field do %>new."<%= f.second_field %>"<% else %>NULL<% end %>
     );
     <% end %>
     return new;

--- a/lib/plenario2/actions/templates/create_trigger.sql.eex
+++ b/lib/plenario2/actions/templates/create_trigger.sql.eex
@@ -1,4 +1,4 @@
-CREATE TRIGGER <%= trigger_name %>
-  BEFORE INSERT ON <%= table_name %>
+CREATE TRIGGER "<%= trigger_name %>"
+  BEFORE INSERT ON "<%= table_name %>"
     FOR EACH ROW
-      EXECUTE PROCEDURE <%= function_name %>();
+      EXECUTE PROCEDURE "<%= function_name %>"();

--- a/lib/plenario2/actions/templates/drop_table.sql.eex
+++ b/lib/plenario2/actions/templates/drop_table.sql.eex
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS <%= table_name %>;
+DROP TABLE IF EXISTS "<%= table_name %>";

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario2.Mixfile do
   def project do
     [
       app: :plenario2,
-      version: "0.0.3",
+      version: "0.0.4",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,

--- a/test/plenario2/data_set_actions_test.exs
+++ b/test/plenario2/data_set_actions_test.exs
@@ -67,4 +67,24 @@ defmodule DataSetActionsTest do
       DataSetActions.drop_data_set_table!(meta)
     end
   end
+
+  test "with a funky field name", context do
+    DataSetFieldActions.create(context.meta.id, "to-day", "integer")
+    VirtualDateFieldActions.create(context.meta.id, "year", "month", "to-day")
+
+    DataSetActions.create_data_set_table!(context.meta)
+
+    insert = """
+    INSERT INTO #{context.table_name}
+    VALUES
+      ('abc123', 1.0, 1.0, 2017, 1, 1, 1);
+    """
+    Ecto.Adapters.SQL.query(Repo, insert)
+
+    query = """
+    SELECT * FROM #{context.table_name}
+    """
+    {:ok, result} = Ecto.Adapters.SQL.query(Repo, query)
+    assert result.rows == [["abc123", 1.0, 1.0, 2017, 1, 1, 1, {{2017, 1, 1}, {0, 0, 0, 0}}, {{2017, 1, 1}, {0, 0, 0, 0}}, %Geo.Point{coordinates: {1.0, 1.0}, srid: 4326}]]
+  end
 end

--- a/test/plenario2/data_set_actions_test.exs
+++ b/test/plenario2/data_set_actions_test.exs
@@ -49,4 +49,22 @@ defmodule DataSetActionsTest do
     DataSetActions.create_data_set_table!(context.meta)
     DataSetActions.drop_data_set_table!(context.meta)
   end
+
+  describe "with non-alnum characters" do
+    test "create with a dash in the name", context do
+      {:ok, meta} = MetaActions.update_name(context.meta, "chicago - data")
+      DataSetActions.create_data_set_table!(meta)
+    end
+
+    test "create with non latin chars", context do
+      {:ok, meta} = MetaActions.update_name(context.meta, "進撃の巨人")
+      DataSetActions.create_data_set_table!(meta)
+    end
+
+    test "drop", context do
+      {:ok, meta} = MetaActions.update_name(context.meta, "chicago - data")
+      DataSetActions.create_data_set_table!(meta)
+      DataSetActions.drop_data_set_table!(meta)
+    end
+  end
 end


### PR DESCRIPTION
If a Meta's name contained an illegal character, then the data set
actions would fail. For example, if a data set was named "Chicago Beach
Lab - DNA Tests" the `-` in the name would bomb the entire thing.

After reading and experimenting a lot, the easiest and most reliable
solution is to just quote every name -- table names, function names,
trigger names -- that could contain unlexible values. When surrounded by
quotes, everything is clean. This works for hyphens and non-latin
characters.

fixes #135