### PR TITLE
Release Migrate CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plenario2
+# Plenario
 [![Build Status](https://travis-ci.org/UrbanCCD-UChicago/plenario2.svg?branch=master)](https://travis-ci.org/UrbanCCD-UChicago/plenario2)
 [![Coverage Status](https://coveralls.io/repos/github/UrbanCCD-UChicago/plenario2/badge.svg?branch=master)](https://coveralls.io/github/UrbanCCD-UChicago/plenario2?branch=master)
 
@@ -112,3 +112,10 @@ To deploy, run `./deploy {{ version number }} {{ hostname }}`
 
 **Note:** you will need the hostname configured in your local SSH config. You
 should also have configured your AWS credentials set up (`$ aws config`).
+
+### Deployments with Migrations
+
+If the latest changes have deployments, there's a convenience wrapper included
+to run the changes. all you have to do is append `--run-migrations` to the
+end of the deployment command:
+`./deploy {{ version_number }} {{ hostname }} --run-migrations`.

--- a/deploy
+++ b/deploy
@@ -16,6 +16,19 @@ if [ -z "$TAG" ]; then echo -e "${RED}you need to specify a release number\nexit
 TARGET=$2
 if [ -z "$TARGET" ]; then echo -e "${RED}you need to specify a target machine to deploy to\nexiting...${NORM}"; exit 1; fi
 
+MIGRATE=$3
+if [ "$MIGRATE" == "--run-migrations" ]; then
+  echo -e "${CYAN}we'll run migrations before restarting the app...${NORM}";
+  MIGRATE=true;
+else
+  if [ -z "$MIGRATE" ]; then
+    echo -e "${CYAN}no migrations to be run...${NORM}";
+    MIGRATE=false;
+  else
+    echo -e "${RED}could not understand flag. if you want to run migrations, use '--run-migrations'.${NORM}"; exit 1;
+  fi
+fi
+
 
 echo -e "${CYAN}we're going to deploy version $TAG to $TARGET...${NORM}"
 
@@ -46,8 +59,14 @@ echo -e "\n${CYAN}symlinking plenario2 to $TAG on $TARGET...${NORM}"
 ssh $TARGET "ln -s releases/$TAG/ plenario2"
 
 
+if $MIGRATE ; then
+  echo -e "\n${CYAN}running migrations on $TARGET...${NORM}"
+  ssh $TARGET "./plenario2/bin/plenario migrate"
+fi
+
+
 echo -e "\n${CYAN}starting application back up on $TARGET...${NORM}"
-ssh $TARGET "./plenario2/bin/plenario2 start"
+ssh $TARGET "./plenario2/bin/plenario start"
 
 
 echo -e "\n${GREEN}DONE!${NORM}"

--- a/lib/release_tasks.ex
+++ b/lib/release_tasks.ex
@@ -1,0 +1,68 @@
+defmodule Plenario.ReleaseTasks do
+  @moduledoc """
+  This module defines functions that can be wrapped using the
+  Shell Script API so that certain operations can be executed
+  from a release.
+
+  For example, to run migrations from a release:
+
+    $ /path/to/release/bin/plenario migrate
+
+  Based on https://github.com/bitwalker/distillery/blob/master/docs/Running%20Migrations.md
+  """
+
+  @start_apps [
+    :crypto,
+    :ssl,
+    :postgrex,
+    :ecto
+  ]
+
+  defp myapp, do: :plenario
+
+  def migrate do
+    prepare()
+    Enum.each(repos(), &run_migrations_for/1)
+  end
+
+  defp repos, do: Application.get_env(myapp(), :ecto_repos, [])
+
+  defp migrations_path(repo), do: priv_path_for(repo, "migrations")
+
+  defp priv_dir(app), do: "#{:code.priv_dir(app)}"
+
+  defp prepare do
+    me = myapp()
+
+    IO.puts "Loading #{me}.."
+    # Load the code for myapp, but don't start it
+    :ok = Application.load(me)
+
+    IO.puts "Starting dependencies.."
+    # Start apps necessary for executing migrations
+    Enum.each(@start_apps, &Application.ensure_all_started/1)
+
+    # Start the Repo(s) for myapp
+    IO.puts "Starting repos.."
+    Enum.each(repos(), &(&1.start_link(pool_size: 1)))
+  end
+
+  defp run_migrations_for(repo) do
+    app = Keyword.get(repo.config, :otp_app)
+    IO.puts "Running migrations for #{app}"
+
+    Ecto.Migrator.run(repo, migrations_path(repo), :up, all: true)
+  end
+
+  defp priv_path_for(repo, filename) do
+    app = Keyword.get(repo.config, :otp_app)
+    repo_underscore =
+      repo
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+
+    Path.join([priv_dir(app), repo_underscore, filename])
+  end
+end
+end

--- a/lib/release_tasks.ex
+++ b/lib/release_tasks.ex
@@ -65,4 +65,3 @@ defmodule Plenario.ReleaseTasks do
     Path.join([priv_dir(app), repo_underscore, filename])
   end
 end
-end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.0.6",
+      version: "0.0.7",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/rel/commands/migrate.sh
+++ b/rel/commands/migrate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$RELEASE_ROOT_DIR/bin/plenario command Elixir.Plenario.ReleaseTasks migrate

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -49,5 +49,7 @@ release :plenario do
   set applications: [
     :runtime_tools
   ]
+  set commands: [
+    "migrate": "rel/commands/migrate.sh"
+  ]
 end
-


### PR DESCRIPTION
This adds an executable script that allows us to run migrations from a
release archive rather than uploading the entirety of the source and
having to execute it via `mix`.

You can now run the migrations before starting the application with a
simple flag added to the deploy command:

```
./deploy {{ release_number }} {{ hostname }} --run-migrations
```

:boom: