### PR TITLE
O canada

### DIFF
--- a/lib/plenario_auth/abilities.ex
+++ b/lib/plenario_auth/abilities.ex
@@ -1,7 +1,7 @@
 defmodule PlenarioAuth.Abilities do
   @moduledoc """
-  Defines auhtorization capabilities for users in relation to resources. For example, we only
-  want the user who owns a meta to be able to edit it.
+  Defines authorization abilities for users in relation to resources. For
+  example, we only want the user who owns a meta to be able to edit it.
   """
 
   alias Plenario.Schemas.{
@@ -18,50 +18,93 @@ defmodule PlenarioAuth.Abilities do
   defimpl Canada.Can, for: User do
 
     @doc """
-    For all create, edit, delete actions of a Meta, ensure the user is the owner
-    otherwaise disallow.
+    Admin users can perform any action, regardless of who owns the resource.
     """
-    def can?(nil, _, _ = %Meta{}), do: false
-    def can?(%User{id: user_id}, _, meta = %Meta{}), do: meta.user_id == user_id
+    def can?(%User{is_admin: true}, _, _), do: true
 
     @doc """
-    For all create, edit, delete actions of a DataSetField, ensure the user
-    is the owner of the related Meta otherwaise disallow.
+    Anonymous users can only access the Meta index and show.
     """
-    def can?(nil, _, _ = %DataSetField{}), do: false
-    def can?(%User{id: user_id}, _, field = %DataSetField{}) do
-      meta = MetaActions.get(field.meta_id)
+    def can?(nil, action, %Meta{}) when action in [:index, :show], do: true
+    def can?(nil, _, %Meta{}), do: false
+
+    @doc """
+    Authenticated users can only access the Meta index and show, unless they
+    are the owner of the Meta.
+    """
+    def can?(%User{id: user_id}, _, %Meta{user_id: user_id}), do: true
+    def can?(%User{id: user_id}, action, %Meta{}) when action in [:index, :show], do: true
+    def can?(%User{id: user_id}, _, %Meta{}), do: false
+
+    @doc """
+    Anonymous users have no access to DataSetField.
+    """
+    def can?(nil, _, %DataSetField{}), do: false
+
+    @doc """
+    Authenticated users who own the DataSetField's parent Meta are the only
+    users able to access it.
+    """
+    def can?(%User{id: user_id}, _, %DataSetField{meta_id: meta_id}) do
+      meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
 
     @doc """
-    For all create, edit, delete actions of a VirtualDateField, ensure the user
-    is the owner of the related Meta otherwaise disallow.
+    Anonymous users have no access to VirtualDateField.
     """
-    def can?(nil, _, _ = %VirtualDateField{}), do: false
-    def can?(%User{id: user_id}, _, field = %VirtualDateField{}) do
-      meta = MetaActions.get(field.meta_id)
+    def can?(nil, _, %VirtualDateField{}), do: false
+
+    @doc """
+    Authenticated users who own the VirtualDateField's parent Meta are the only
+    users able to access it.
+    """
+    def can?(%User{id: user_id}, _, %VirtualDateField{meta_id: meta_id}) do
+      meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
 
     @doc """
-    For all create, edit, delete actions of a VirtualPointField, ensure the user
-    is the owner of the related Meta otherwaise disallow.
+    Anonymous users have no access to VirtualPointField.
     """
-    def can?(nil, _, _ = %VirtualPointField{}), do: false
-    def can?(%User{id: user_id}, _, field = %VirtualPointField{}) do
-      meta = MetaActions.get(field.meta_id)
+    def can?(nil, _, %VirtualPointField{}), do: false
+
+    @doc """
+    Authenticated users who own the VirtualPointField's parent Meta are the only
+    users able to access it.
+    """
+    def can?(%User{id: user_id}, _, %VirtualPointField{meta_id: meta_id}) do
+      meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
 
     @doc """
-    For all create, edit, delete actions of a UniqueConstraint, ensure the user
-    is the owner of the related Meta otherwaise disallow.
+    Anonymous users have no access to UniqueConstraint.
     """
-    def can?(nil, _, _ = %UniqueConstraint{}), do: false
-    def can?(%User{id: user_id}, _, constraint = %UniqueConstraint{}) do
-      meta = MetaActions.get(constraint.meta_id)
+    def can?(nil, _, %UniqueConstraint{}), do: false
+
+    @doc """
+    Authenticated users who own the UniqueConstraint's parent Meta are the only
+    users able to access it.
+    """
+    def can?(%User{id: user_id}, _, %UniqueConstraint{meta_id: meta_id}) do
+      meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
+
+    @doc """
+    Anonymous users can only access the User index and show.
+    """
+    def can?(nil, action, %User{}) when action in [:index, :show], do: true
+    def can?(nil, _, %User{}), do: false
+
+    @doc """
+    Authenticated users can only access another User's index and show, unless
+    they are the requested User -- then obviously they can do whatever with
+    themselves... I mean it's a free country and all.
+    """
+    def can?(%User{id: user_id}, _, %User{id: user_id}), do: true
+    def can?(%User{}, action, %User{}) when action in [:index, :show], do: true
+    def can?(%User{}, _, %User{}), do: false
   end
 end

--- a/lib/plenario_auth/abilities.ex
+++ b/lib/plenario_auth/abilities.ex
@@ -15,6 +15,17 @@ defmodule PlenarioAuth.Abilities do
 
   alias Plenario.Actions.MetaActions
 
+  defimpl Canada.Can, for: Atom do
+
+    @doc """
+    Anonymous users can only access the :index and :show actions of
+    Metas and Users.
+    """
+    def can?(nil, action, %Meta{}) when action in [:index, :show], do: true
+    def can?(nil, action, %User{}) when action in [:index, :show], do: true
+    def can?(nil, _, _), do: false
+  end
+
   defimpl Canada.Can, for: User do
 
     @doc """
@@ -23,23 +34,12 @@ defmodule PlenarioAuth.Abilities do
     def can?(%User{is_admin: true}, _, _), do: true
 
     @doc """
-    Anonymous users can only access the Meta index and show.
-    """
-    def can?(nil, action, %Meta{}) when action in [:index, :show], do: true
-    def can?(nil, _, %Meta{}), do: false
-
-    @doc """
     Authenticated users can only access the Meta index and show, unless they
     are the owner of the Meta.
     """
     def can?(%User{id: user_id}, _, %Meta{user_id: user_id}), do: true
     def can?(%User{id: user_id}, action, %Meta{}) when action in [:index, :show], do: true
     def can?(%User{id: user_id}, _, %Meta{}), do: false
-
-    @doc """
-    Anonymous users have no access to DataSetField.
-    """
-    def can?(nil, _, %DataSetField{}), do: false
 
     @doc """
     Authenticated users who own the DataSetField's parent Meta are the only
@@ -51,11 +51,6 @@ defmodule PlenarioAuth.Abilities do
     end
 
     @doc """
-    Anonymous users have no access to VirtualDateField.
-    """
-    def can?(nil, _, %VirtualDateField{}), do: false
-
-    @doc """
     Authenticated users who own the VirtualDateField's parent Meta are the only
     users able to access it.
     """
@@ -63,11 +58,6 @@ defmodule PlenarioAuth.Abilities do
       meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
-
-    @doc """
-    Anonymous users have no access to VirtualPointField.
-    """
-    def can?(nil, _, %VirtualPointField{}), do: false
 
     @doc """
     Authenticated users who own the VirtualPointField's parent Meta are the only
@@ -79,11 +69,6 @@ defmodule PlenarioAuth.Abilities do
     end
 
     @doc """
-    Anonymous users have no access to UniqueConstraint.
-    """
-    def can?(nil, _, %UniqueConstraint{}), do: false
-
-    @doc """
     Authenticated users who own the UniqueConstraint's parent Meta are the only
     users able to access it.
     """
@@ -91,12 +76,6 @@ defmodule PlenarioAuth.Abilities do
       meta = MetaActions.get(meta_id)
       meta.user_id == user_id
     end
-
-    @doc """
-    Anonymous users can only access the User index and show.
-    """
-    def can?(nil, action, %User{}) when action in [:index, :show], do: true
-    def can?(nil, _, %User{}), do: false
 
     @doc """
     Authenticated users can only access another User's index and show, unless

--- a/lib/plenario_web/controllers/web/data_set_controller.ex
+++ b/lib/plenario_web/controllers/web/data_set_controller.ex
@@ -12,13 +12,7 @@ defmodule PlenarioWeb.Web.DataSetController do
 
   alias PlenarioWeb.Web.ControllerUtils
 
-  # plug(
-  #   :load_and_authorize_resource,
-  #   model: Meta,
-  #   id_name: "id",
-  #   id_field: "id",
-  #   except: [:show, :list]
-  # )
+  plug :authorize_resource, model: Meta
 
   def show(conn, %{"id" => id}) do
     meta = MetaActions.get(id, with_user: true, with_fields: true, with_constraints: true)

--- a/lib/plenario_web/controllers/web/data_set_field_controller.ex
+++ b/lib/plenario_web/controllers/web/data_set_field_controller.ex
@@ -7,6 +7,8 @@ defmodule PlenarioWeb.Web.DataSetFieldController do
 
   alias PlenarioWeb.Web.ControllerUtils
 
+  plug :authorize_resource, model: DataSetField
+
   def edit(conn, %{"dsid" => _, "id" => id}) do
     field = DataSetFieldActions.get(id)
     changeset = DataSetFieldActions.edit(field)

--- a/lib/plenario_web/controllers/web/me_controller.ex
+++ b/lib/plenario_web/controllers/web/me_controller.ex
@@ -3,7 +3,9 @@ defmodule PlenarioWeb.Web.MeController do
 
   alias Plenario.Actions.{MetaActions, UserActions}
 
-  alias PlenarioAuth
+  alias Plenario.Schemas.User
+
+  plug :authorize_resource, model: User
 
   def index(conn, _) do
     user = Guardian.Plug.current_resource(conn)

--- a/lib/plenario_web/controllers/web/unique_constraint_controller.ex
+++ b/lib/plenario_web/controllers/web/unique_constraint_controller.ex
@@ -7,6 +7,8 @@ defmodule PlenarioWeb.Web.UniqueConstraintController do
 
   alias PlenarioWeb.Web.ControllerUtils
 
+  plug :authorize_resource, model: UniqueConstraint
+
   def new(conn, %{"dsid" => dsid}) do
     changeset = UniqueConstraintActions.new()
     action = unique_constraint_path(conn, :create, dsid)

--- a/lib/plenario_web/controllers/web/virtual_date_controller.ex
+++ b/lib/plenario_web/controllers/web/virtual_date_controller.ex
@@ -7,6 +7,8 @@ defmodule PlenarioWeb.Web.VirtualDateController do
 
   alias PlenarioWeb.Web.ControllerUtils
 
+  plug :authorize_resource, model: VirtualDateField
+
   def new(conn, %{"dsid" => dsid}) do
     changeset = VirtualDateFieldActions.new()
     action = virtual_date_path(conn, :create, dsid)

--- a/lib/plenario_web/controllers/web/virtual_point_controller.ex
+++ b/lib/plenario_web/controllers/web/virtual_point_controller.ex
@@ -7,6 +7,8 @@ defmodule PlenarioWeb.Web.VirtualPointController do
 
   alias PlenarioWeb.Web.ControllerUtils
 
+  plug :authorize_resource, model: VirtualPointField
+
   def new(conn, %{"dsid" => dsid}) do
     changeset = VirtualPointFieldActions.new()
     action = virtual_point_path(conn, :create, dsid)

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -32,7 +32,7 @@ defmodule PlenarioWeb.Router do
   end
 
   ##
-  # anaon accessible path
+  # public web paths
   scope "/", PlenarioWeb.Web do
     pipe_through [:browser, :maybe_authenticated]
 
@@ -46,13 +46,8 @@ defmodule PlenarioWeb.Router do
     post "/login", AuthController, :login
     post "/register", AuthController, :register
     post "/logout", AuthController, :logout
-  end
 
-  ##
-  # auth required paths
-  scope "/", PlenarioWeb.Web do
-    pipe_through [:browser, :ensure_authenticated]
-
+    # user pages
     get "/me", MeController, :index
     get "/me/edit", MeController, :edit
     put "/me/update", MeController, :update

--- a/lib/plenario_web/templates/web/data_set/show.html.eex
+++ b/lib/plenario_web/templates/web/data_set/show.html.eex
@@ -8,7 +8,7 @@
   #map { height: 500px }
 </style>
 
-<% is_owner = @current_user.id == @meta.user_id %>
+<% is_owner = @current_user != nil and @current_user.id == @meta.user_id %>
 
 <h2>
   <%= @meta.name %>

--- a/test/plenario_auth/abilities_test.exs
+++ b/test/plenario_auth/abilities_test.exs
@@ -1,0 +1,195 @@
+defmodule PlenarioAuth.Testing.AbilitiesTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
+
+  alias Plenario.Actions.{
+    UserActions,
+    MetaActions,
+    DataSetFieldActions,
+    VirtualDateFieldActions,
+    VirtualPointFieldActions,
+    UniqueConstraintActions
+  }
+
+  setup %{reg_user: user} do
+    {:ok, meta} = MetaActions.create("name", user, "https://example.com/", "csv")
+    {:ok, field} = DataSetFieldActions.create(meta, "name", "text")
+    {:ok, vdf} = VirtualDateFieldActions.create(meta, field.id)
+    {:ok, vpf} = VirtualPointFieldActions.create(meta, field.id)
+    {:ok, uc} = UniqueConstraintActions.create(meta, [field.id])
+
+    {:ok, [meta: meta, field: field, vdf: vdf, vpf: vpf, uc: uc]}
+  end
+
+  describe "anonymous user" do
+    @tag :anon
+    test "can access meta show", %{conn: conn, meta: meta} do
+      conn
+      |> get(data_set_path(conn, :show, meta.id))
+      |> html_response(:ok)
+    end
+
+    @tag :anon
+    test "are forbidden from all other meta actions", %{conn: conn, meta: meta} do
+      conn
+      |> get(data_set_path(conn, :edit, meta.id))
+      |> response(:forbidden)
+    end
+
+    @tag :anon
+    test "are forbidden from data set field actions", %{conn: conn, meta: meta, field: field} do
+      conn
+      |> get(data_set_field_path(conn, :edit, meta.id, field.id))
+      |> response(:forbidden)
+    end
+
+    @tag :anon
+    test "are forbidden from virtual date field actions", %{conn: conn, meta: meta, vdf: vdf} do
+      conn
+      |> get(virtual_date_path(conn, :edit, meta.id, vdf.id))
+      |> response(:forbidden)
+    end
+
+    @tag :anon
+    test "are forbidden from virtual point field actions", %{conn: conn, meta: meta, vpf: vpf} do
+      conn
+      |> get(virtual_point_path(conn, :edit, meta.id, vpf.id))
+      |> response(:forbidden)
+    end
+
+    @tag :anon
+    test "are forbidden from unique constraint actions", %{conn: conn, meta: meta, uc: uc} do
+      conn
+      |> get(unique_constraint_path(conn, :edit, meta.id, uc.id))
+      |> response(:forbidden)
+    end
+  end
+
+  describe "authenticated user who owns the parent meta" do
+    @tag :auth
+    test "can access all meta actions", %{conn: conn, meta: meta} do
+      conn
+      |> get(data_set_path(conn, :edit, meta.id))
+      |> html_response(:ok)
+    end
+
+    @tag :auth
+    test "can access all data set field actions", %{conn: conn, meta: meta, field: field} do
+      conn
+      |> get(data_set_field_path(conn, :edit, meta.id, field.id))
+      |> html_response(:ok)
+    end
+
+    @tag :auth
+    test "can access all virtual date field actions", %{conn: conn, meta: meta, vdf: vdf} do
+      conn
+      |> get(virtual_date_path(conn, :edit, meta.id, vdf.id))
+      |> html_response(:ok)
+    end
+
+    @tag :auth
+    test "can access all virtual point field actions", %{conn: conn, meta: meta, vpf: vpf} do
+      conn
+      |> get(virtual_point_path(conn, :edit, meta.id, vpf.id))
+      |> html_response(:ok)
+    end
+
+    @tag :auth
+    test "can access all unique constraint actions", %{conn: conn, meta: meta, uc: uc} do
+      conn
+      |> get(unique_constraint_path(conn, :edit, meta.id, uc.id))
+      |> html_response(:ok)
+    end
+  end
+
+  describe "authenticated user who doesn't own the parent meta" do
+    setup do
+      {:ok, user} = UserActions.create("new user", "email@example.com", "password")
+      {:ok, meta} = MetaActions.create("another name", user, "https://example.com/1", "csv")
+      {:ok, field} = DataSetFieldActions.create(meta, "name", "text")
+      {:ok, vdf} = VirtualDateFieldActions.create(meta, field.id)
+      {:ok, vpf} = VirtualPointFieldActions.create(meta, field.id)
+      {:ok, uc} = UniqueConstraintActions.create(meta, [field.id])
+
+      {:ok, [new_meta: meta, new_field: field, new_vdf: vdf, new_vpf: vpf, new_uc: uc]}
+    end
+
+    @tag :auth
+    test "can access meta show", %{conn: conn, new_meta: meta} do
+      conn
+      |> get(data_set_path(conn, :show, meta.id))
+      |> html_response(:ok)
+    end
+
+    @tag :auth
+    test "are forbidden from all other meta actions", %{conn: conn, new_meta: meta} do
+      conn
+      |> get(data_set_path(conn, :edit, meta.id))
+      |> response(:forbidden)
+    end
+
+    @tag :auth
+    test "are forbidden from data set field action", %{conn: conn, new_meta: meta, new_field: field} do
+      conn
+      |> get(data_set_field_path(conn, :edit, meta.id, field.id))
+      |> response(:forbidden)
+    end
+
+    @tag :auth
+    test "are forbidden from virtual date field actions", %{conn: conn, new_meta: meta, new_vdf: vdf} do
+      conn
+      |> get(virtual_date_path(conn, :edit, meta.id, vdf.id))
+      |> response(:forbidden)
+    end
+
+    @tag :auth
+    test "are forbidden from virtual point field actions", %{conn: conn, new_meta: meta, new_vpf: vpf} do
+      conn
+      |> get(virtual_point_path(conn, :edit, meta.id, vpf.id))
+      |> response(:forbidden)
+    end
+
+    @tag :auth
+    test "are forbidden from unique constraint actions", %{conn: conn, new_meta: meta, new_uc: uc} do
+      conn
+      |> get(unique_constraint_path(conn, :edit, meta.id, uc.id))
+      |> response(:forbidden)
+    end
+  end
+
+  describe "admin users" do
+    @tag :admin
+    test "can access all meta actions", %{conn: conn, meta: meta} do
+      conn
+      |> get(data_set_path(conn, :edit, meta.id))
+      |> html_response(:ok)
+    end
+
+    @tag :admin
+    test "can access all data set field actions", %{conn: conn, meta: meta, field: field} do
+      conn
+      |> get(data_set_field_path(conn, :edit, meta.id, field.id))
+      |> html_response(:ok)
+    end
+
+    @tag :admin
+    test "can access all virtual date field actions", %{conn: conn, meta: meta, vdf: vdf} do
+      conn
+      |> get(virtual_date_path(conn, :edit, meta.id, vdf.id))
+      |> html_response(:ok)
+    end
+
+    @tag :admin
+    test "can access all virtual point field actions", %{conn: conn, meta: meta, vpf: vpf} do
+      conn
+      |> get(virtual_point_path(conn, :edit, meta.id, vpf.id))
+      |> html_response(:ok)
+    end
+
+    @tag :admin
+    test "can access all unique constraint actions", %{conn: conn, meta: meta, uc: uc} do
+      conn
+      |> get(unique_constraint_path(conn, :edit, meta.id, uc.id))
+      |> html_response(:ok)
+    end
+  end
+end

--- a/test/plenario_auth/admin_plug_test.exs
+++ b/test/plenario_auth/admin_plug_test.exs
@@ -1,0 +1,24 @@
+defmodule PlenarioAuth.Testing.AdminPlugTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
+
+  @tag :anon
+  test "anonymous users cannot access admin routes", %{conn: conn} do
+    conn
+    |> get(user_path(conn, :index))
+    |> response(:unauthorized)
+  end
+
+  @tag :auth
+  test "authenticated regular users cannot access admin routes", %{conn: conn} do
+    conn
+    |> get(user_path(conn, :index))
+    |> response(:forbidden)
+  end
+
+  @tag :admin
+  test "authenticated admin status users can access admin routes", %{conn: conn} do
+    conn
+    |> get(user_path(conn, :index))
+    |> html_response(:ok)
+  end
+end

--- a/test/plenario_web/views/error_view_test.exs
+++ b/test/plenario_web/views/error_view_test.exs
@@ -1,5 +1,5 @@
-defmodule PlenarioWeb.ErrorViewTest do
-  use PlenarioWeb.ConnCase, async: true
+defmodule PlenarioWeb.Testing.ErrorViewTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View

--- a/test/plenario_web/views/layout_view_test.exs
+++ b/test/plenario_web/views/layout_view_test.exs
@@ -1,3 +1,3 @@
-defmodule PlenarioWeb.LayoutViewTest do
-  use PlenarioWeb.ConnCase, async: true
+defmodule PlenarioWeb.Testing.LayoutViewTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
 end

--- a/test/plenario_web/views/page_view_test.exs
+++ b/test/plenario_web/views/page_view_test.exs
@@ -1,3 +1,3 @@
-defmodule PlenarioWeb.PageViewTest do
-  use PlenarioWeb.ConnCase, async: true
+defmodule PlenarioWeb.Testing.PageViewTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,4 +1,4 @@
-defmodule PlenarioWeb.ConnCase do
+defmodule PlenarioWeb.Testing.ConnCase do
   @moduledoc """
   This module defines the test case to be used by
   tests that require setting up a connection.
@@ -57,10 +57,10 @@ defmodule PlenarioWeb.ConnCase do
         tags[:auth] ->
           post(
             conn_,
-            auth_path(conn_, :do_login, %{
+            auth_path(conn_, :login, %{
               "user" => %{
-                "email_address" => "regular@example.com",
-                "plaintext_password" => "password"
+                "email" => "regular@example.com",
+                "password" => "password"
               }
             })
           )
@@ -68,10 +68,10 @@ defmodule PlenarioWeb.ConnCase do
         tags[:admin] ->
           post(
             conn_,
-            auth_path(conn_, :do_login, %{
+            auth_path(conn_, :login, %{
               "user" => %{
-                "email_address" => "admin@example.com",
-                "plaintext_password" => "password"
+                "email" => "admin@example.com",
+                "password" => "password"
               }
             })
           )


### PR DESCRIPTION
This takes care of a lot of auth issues with not a lot of code:

- `Canada.Can` implementation for anonymous users (via `for: Atom`)
- `Canada.Can` implementation for authenticated users
- simplified routing config
- tests for abilities (`can?` funcs) and plugs (user and admin)

fixes and closes #157 
