### PR TITLE
Redo admin user notes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -24,3 +24,8 @@
 .leaflet-mouse-marker{background-color:#fff;cursor:crosshair}.leaflet-draw-tooltip{background:#363636;background:rgba(0,0,0,0.5);border:1px solid transparent;-webkit-border-radius:4px;border-radius:4px;color:#fff;font:12px/18px "Helvetica Neue",Arial,Helvetica,sans-serif;margin-left:20px;margin-top:-21px;padding:4px 8px;position:absolute;visibility:hidden;white-space:nowrap;z-index:6}.leaflet-draw-tooltip:before{border-right:6px solid black;border-right-color:rgba(0,0,0,0.5);border-top:6px solid transparent;border-bottom:6px solid transparent;content:"";position:absolute;top:7px;left:-7px}
 .leaflet-error-draw-tooltip{background-color:#f2dede;border:1px solid #e6b6bd;color:#b94a48}.leaflet-error-draw-tooltip:before{border-right-color:#e6b6bd}.leaflet-draw-tooltip-single{margin-top:-12px}.leaflet-draw-tooltip-subtext{color:#f8d5e4}.leaflet-draw-guide-dash{font-size:1%;opacity:.6;position:absolute;width:5px;height:5px}.leaflet-edit-marker-selected{background-color:rgba(254,87,161,0.1);border:4px dashed rgba(254,87,161,0.6);-webkit-border-radius:4px;border-radius:4px;box-sizing:content-box}
 .leaflet-edit-move{cursor:move}.leaflet-edit-resize{cursor:pointer}.leaflet-oldie .leaflet-draw-toolbar{border:1px solid #999}
+
+.dotborder {
+   border-bottom: dotted 1px;
+   border-color: #ccc
+}

--- a/config/config.exs
+++ b/config/config.exs
@@ -45,7 +45,7 @@ config :canary,
 
 
 # configure bamboo (email)
-config :plenario, Plenario.Mailer, adapter: Bamboo.LocalAdapter
+config :plenario, PlenarioMailer, adapter: Bamboo.LocalAdapter
 config :plenario, :email_sender, "plenario@uchicago.edu"
 config :plenario, :email_subject, "Plenario Notification"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -38,4 +38,4 @@ config :plenario, PlenarioEtl,
 
 
 # configure bamboo (email)
-config :plenario, Plenario.Mailer, adapter: Bamboo.TestAdapter
+config :plenario, PlenarioMailer, adapter: Bamboo.TestAdapter

--- a/lib/plenario_mailer/admin_user_note.ex
+++ b/lib/plenario_mailer/admin_user_note.ex
@@ -13,16 +13,16 @@ defmodule PlenarioMailer.Schemas.AdminUserNote do
   use Ecto.Schema
 
   schema "admin_user_notes" do
-    field(:message, :string)
-    field(:should_email, :boolean, default: false)
-    field(:acknowledged, :boolean, default: false)
+    field :message, :string
+    field :should_email, :boolean, default: false
+    field :acknowledged, :boolean, default: false
 
-    timestamps(type: :utc_datetime)
+    timestamps type: :utc_datetime
 
-    belongs_to(:admin, Plenario.Schemas.User, foreign_key: :admin_id)
-    belongs_to(:user, Plenario.Schemas.User, foreign_key: :user_id)
-    belongs_to(:meta, Plenario.Schemas.Meta)
-    belongs_to(:etl_job, PlenarioEtl.Schemas.EtlJob)
-    belongs_to(:export_job, PlenarioExport.Schemas.ExportJob)
+    belongs_to :admin, Plenario.Schemas.User, foreign_key: :admin_id
+    belongs_to :user, Plenario.Schemas.User, foreign_key: :user_id
+    belongs_to :meta, Plenario.Schemas.Meta
+    belongs_to :etl_job, PlenarioEtl.Schemas.EtlJob
+    belongs_to :export_job, PlenarioExport.Schemas.ExportJob
   end
 end

--- a/lib/plenario_mailer/admin_user_note_changesets.ex
+++ b/lib/plenario_mailer/admin_user_note_changesets.ex
@@ -1,69 +1,85 @@
 defmodule PlenarioMailer.Changesets.AdminUserNoteChangesets do
   @moduledoc """
-  This module provides functions for creating changesets for
-  AdminUserNote structs.
+  This module defines functions used to create and update changesets for
+  the DataSetField schema.
   """
 
   import Ecto.Changeset
 
   alias PlenarioMailer.Schemas.AdminUserNote
 
-  @typedoc """
-  Verbose map of params for create_for_meta
-  """
   @type create_meta_params :: %{
-          note: String.t(),
-          should_email: boolean,
-          admin_id: integer,
-          user_id: integer,
-          meta_id: integer
-        }
+    meta_id: integer,
+    admin_id: integer,
+    user_id: integer,
+    message: String.t(),
+    should_email: boolean
+  }
 
-  @new_create_meta_param_keys [:note, :should_email, :admin_id, :user_id, :meta_id]
+  # @type create_etl_params :: %{
+  #   etl_job_id: integer,
+  #   admin_id: integer,
+  #   user_id: integer,
+  #   message: String.t(),
+  #   should_email: boolean
+  # }
 
-  def new_for_meta() do
-    %AdminUserNote{}
-    |> cast(%{}, @new_create_meta_param_keys)
-  end
+  # @type create_export_params :: %{
+  #   export_job_id: integer,
+  #   admin_id: integer,
+  #   user_id: integer,
+  #   message: String.t(),
+  #   should_email: boolean
+  # }
 
-  @doc """
-  Creates a new AdminUserNote that is related to a Meta entity
-  """
+  @create_meta_keys [:meta_id, :admin_id, :user_id, :message, :should_email]
+
+  # @create_etl_keys [:etl_job_id, :admin_id, :user_id, :message, :should_email]
+
+  # @create_export_keys [:export_job_id, :admin_id, :user_id, :message, :should_email]
+
+  @spec new_for_meta() :: Ecto.Changeset.t()
+  def new_for_meta(), do: %AdminUserNote{} |> cast(%{}, @create_meta_keys)
+
+  # @spec new_for_etl() :: Ecto.Changeset.t()
+  # def new_for_etl(), do: %AdminUserNote{} |> cast(%{}, @create_etl_keys)
+
+  # @spec new_for_export() :: Ecto.Changeset.t()
+  # def new_for_export(), do: %AdminUserNote{} |> cast(%{}, @create_export_keys)
+
   @spec create_for_meta(params :: create_meta_params) :: Ecto.Changeset.t()
   def create_for_meta(params) do
     %AdminUserNote{}
-    |> cast(params, @new_create_meta_param_keys)
-    |> validate_required([:note, :admin_id, :user_id, :meta_id])
+    |> cast(params, @create_meta_keys)
+    |> validate_required(@create_meta_keys)
+    |> cast_assoc(:meta)
     |> cast_assoc(:admin)
     |> cast_assoc(:user)
-    |> cast_assoc(:meta)
   end
 
-  # def create_for_etl_job(struct, params) do
-  #   struct
-  #   |> cast(params, [:note, :should_email, :admin_id, :user_id, :etl_job_id])
-  #   |> validate_required([:note, :admin_id, :user_id, :etl_job_id])
-  #   |> cast_assoc(:admin)
-  #   |> cast_assoc(:user)
+  # @spec create_for_etl(params :: create_etl_params) :: Ecto.Changeset.t()
+  # def create_for_etl(params) do
+  #   %AdminUserNote{}
+  #   |> cast(params, @create_etl_keys)
+  #   |> validate_required(@create_etl_keys)
   #   |> cast_assoc(:etl_job)
-  # end
-
-  # def create_for_export_job(struct, params) do
-  #   struct
-  #   |> cast(params, [:note, :should_email, :admin_id, :user_id, :export_job_id])
-  #   |> validate_required([:note, :admin_id, :user_id, :export_job_id])
   #   |> cast_assoc(:admin)
   #   |> cast_assoc(:user)
-  #   |> cast_assoc(:export_job)
   # end
 
-  @doc """
-  Creates a changeset to update a given note's acknowledged bit in the database
-  """
-  @spec update_acknowledged(note :: AdminUserNote, params :: %{acknowledged: boolean}) ::
-          Ecto.Changeset.t()
-  def update_acknowledged(note, params) do
-    note
+  # @spec create_for_export(params :: create_export_params) :: Ecto.Changeset.t()
+  # def create_for_export(params) do
+  #   %AdminUserNote{}
+  #   |> cast(params, @create_export_keys)
+  #   |> validate_required(@create_export_keys)
+  #   |> cast_assoc(:export_job)
+  #   |> cast_assoc(:admin)
+  #   |> cast_assoc(:user)
+  # end
+
+  @spec update_acknowledged(instance :: AdminUserNote, params :: %{acknowleged: boolean}) :: Ecto.Changeset.t()
+  def update_acknowledged(instance, params) do
+    instance
     |> cast(params, [:acknowledged])
     |> validate_required([:acknowledged])
   end

--- a/lib/plenario_web/controllers/web/admin_user_note_controller.ex
+++ b/lib/plenario_web/controllers/web/admin_user_note_controller.ex
@@ -1,0 +1,11 @@
+defmodule PlenarioWeb.Web.AdminUserNoteController do
+  use PlenarioWeb, :web_controller
+
+  alias PlenarioMailer.Actions.AdminUserNoteActions
+
+  def mark_acknowledged(conn, %{"id" => id, "redir" => redir}) do
+    note = AdminUserNoteActions.get(id)
+    AdminUserNoteActions.mark_acknowledged(note)
+    redirect(conn, to: redir)
+  end
+end

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -63,6 +63,8 @@ defmodule PlenarioWeb.Router do
     resources "/data-sets/:dsid/constraints", UniqueConstraintController
     resources "/data-sets/:dsid/virtual-dates", VirtualDateController
     resources "/data-sets/:dsid/virtual-points", VirtualPointController
+
+    post "/notes/:id/acknowledge", AdminUserNoteController, :mark_acknowledged
   end
 
   ##

--- a/lib/plenario_web/templates/web/me/index.html.eex
+++ b/lib/plenario_web/templates/web/me/index.html.eex
@@ -10,7 +10,7 @@
 
     <%= if length(@erred_metas) > 0 do %>
     <div class="row">
-      <h3>Erred Data Sets</h3>
+      <h3 class="dotborder">Erred Data Sets</h3>
       <%= for m <- @erred_metas do %>
       <p>
         <strong><%= m.name %></strong><br>
@@ -22,7 +22,7 @@
 
     <%= if length(@new_metas) > 0 do %>
     <div class="row">
-      <h3>Data Sets I'm Working On</h3>
+      <h3 class="dotborder">Data Sets I'm Working On</h3>
       <%= for m <- @new_metas do %>
       <p>
         <strong><%= m.name %></strong><br>
@@ -34,7 +34,7 @@
 
     <%= if length(@needs_approval_metas) > 0 do %>
     <div class="row">
-      <h3>Data Sets Waiting on Admin Approval</h3>
+      <h3 class="dotborder">Data Sets Waiting on Admin Approval</h3>
       <%= for m <- @needs_approval_metas do %>
       <p>
         <strong><%= m.name %></strong><br>
@@ -46,7 +46,7 @@
 
     <%= if length(@awaiting_first_import_metas) > 0 do %>
     <div class="row">
-      <h3>Scheduled First Import Data Sets</h3>
+      <h3 class="dotborder">Scheduled First Import Data Sets</h3>
       <%= for m <- @awaiting_first_import_metas do %>
       <p>
         <strong><%= m.name %></strong><br>
@@ -58,7 +58,7 @@
 
     <%= if length(@ready_metas) > 0 do %>
     <div class="row">
-      <h3>Live Data Sets</h3>
+      <h3 class="dotborder">Live Data Sets</h3>
       <%= for m <- @ready_metas do %>
       <p>
         <strong><%= m.name %></strong><br>
@@ -92,10 +92,21 @@
       <hr>
     </div>
     <div class="row">
-      <h4>Unread</h4>
+      <h4 class="dotborder">Unread</h4>
+      <%= for msg <- @unread_messages do %>
+      <div>
+        <p>
+          <%= msg.message %><br>
+          <%= link "Mark Read", to: admin_user_note_path(@conn, :mark_acknowledged, msg.id, redir: @conn.request_path), method: :post, class: "info pull-right" %>
+        </p>
+      </div>
+      <% end %>
     </div>
     <div class="row">
-      <h4>Archived</h4>
+      <h4 class="dotborder">Archived</h4>
+      <%= for msg <- @read_messages do %>
+      <p><%= msg.message %></p>
+      <% end %>
     </div>
   </div> <!-- /info column -->
 </div>

--- a/lib/plenario_web/views/web/admin_user_note_view.ex
+++ b/lib/plenario_web/views/web/admin_user_note_view.ex
@@ -1,0 +1,3 @@
+defmodule PlenarioWeb.Web.AdminUserNoteView do
+  use PlenarioWeb, :web_view
+end

--- a/test/plenario_mailer/admin_user_note_actions_test.exs
+++ b/test/plenario_mailer/admin_user_note_actions_test.exs
@@ -1,0 +1,71 @@
+defmodule PlenarioMailer.Testing.AdminUserNoteActionsTest do
+  use Plenario.Testing.DataCase, async: true
+
+  alias Plenario.Actions.UserActions
+
+  alias PlenarioMailer.Actions.AdminUserNoteActions
+
+  setup context do
+    user = context[:user]
+    {:ok, _} = UserActions.promote_to_admin(user)
+    context
+  end
+
+  test "create for meta", %{user: user, meta: meta} do
+    {:ok, _} = AdminUserNoteActions.create_for_meta(
+      meta, user, user, "This is a test", false)
+  end
+
+  test "get", %{user: user, meta: meta} do
+    {:ok, n} = AdminUserNoteActions.create_for_meta(
+      meta, user, user, "This is a test", false)
+
+    note = AdminUserNoteActions.get(n.id)
+    assert note.meta_id == meta.id
+    assert note.user_id == user.id
+    assert note.admin_id == user.id
+    refute note.acknowledged
+  end
+
+  test "mark acknowleged", %{user: user, meta: meta} do
+    {:ok, n} = AdminUserNoteActions.create_for_meta(
+      meta, user, user, "This is a test", false)
+
+    {:ok, _} = AdminUserNoteActions.mark_acknowledged(n)
+
+    note = AdminUserNoteActions.get(n.id)
+    assert note.acknowledged
+  end
+
+  describe "list" do
+    setup %{user: user, meta: meta} do
+      {:ok, n} = AdminUserNoteActions.create_for_meta(
+        meta, user, user, "This is a test", false)
+      {:ok, [note: n]}
+    end
+    test "all" do
+      all_notes = AdminUserNoteActions.list()
+      assert length(all_notes) == 1
+    end
+
+    test "unread only" do
+      unread = AdminUserNoteActions.list(unread_only: true)
+      assert length(unread) == 1
+    end
+
+    test "acknowledged only" do
+      read = AdminUserNoteActions.list(acknowledged_only: true)
+      assert length(read) == 0
+    end
+
+    test "for user", %{user: user} do
+      users_notes = AdminUserNoteActions.list(for_user: user)
+      assert length(users_notes) == 1
+    end
+
+    test "for meta", %{meta: meta} do
+      metas_notes = AdminUserNoteActions.list(for_meta: meta)
+      assert length(metas_notes) == 1
+    end
+  end
+end

--- a/test/plenario_mailer/emails_test.exs
+++ b/test/plenario_mailer/emails_test.exs
@@ -1,11 +1,11 @@
-defmodule Plenario.EmailsTest do
-  use Plenario.DataCase, async: true
+defmodule PlenarioMailer.Testing.EmailsTest do
+  use Plenario.Testing.DataCase, async: true
 
-  alias Plenario.Emails
+  alias PlenarioMailer.Emails
 
-  alias Plenario.Actions.AdminUserNoteActions
+  alias PlenarioMailer.Actions.AdminUserNoteActions
 
-  alias PlenarioAuth.UserActions
+  alias Plenario.Actions.UserActions
 
   setup context do
     user = context[:user]
@@ -16,16 +16,16 @@ defmodule Plenario.EmailsTest do
   test :compose_admin_user_note, context do
     {:ok, note} =
       AdminUserNoteActions.create_for_meta(
-        "This is a test",
-        context[:user],
-        context[:user],
         context[:meta],
-        true
+        context[:user],
+        context[:user],
+        "This is a test",
+        false
       )
 
     email = Emails.compose_admin_user_note(note)
     assert email.from == "plenario@uchicago.edu"
-    assert email.to == context.user.email_address
+    assert email.to == context.user.email
     assert email.subject == "Plenario Notification"
     assert email.text_body == "This is a test"
     assert email.html_body == nil

--- a/test/plenario_web/controllers/admin/meta_controller_test.exs
+++ b/test/plenario_web/controllers/admin/meta_controller_test.exs
@@ -3,6 +3,8 @@ defmodule PlenarioWeb.Admin.Testing.MetaControllerTest do
 
   alias Plenario.Actions.MetaActions
 
+  alias PlenarioMailer.Actions.AdminUserNoteActions
+
   setup %{admin_user: user} do
     {:ok, meta} = MetaActions.create("name", user, "https://example.com/", "csv")
 
@@ -31,17 +33,26 @@ defmodule PlenarioWeb.Admin.Testing.MetaControllerTest do
   test "approve", %{conn: conn, meta: meta} do
     {:ok, _} = MetaActions.submit_for_approval(meta)
 
+    notes = AdminUserNoteActions.list(for_meta: meta)
+    assert length(notes) == 0
+
     conn
     |> post(meta_path(conn, :approve, meta.id))
     |> html_response(:found)
 
     meta = MetaActions.get(meta.id)
     assert meta.state == "awaiting_first_import"
+
+    notes = AdminUserNoteActions.list(for_meta: meta)
+    assert length(notes) == 1
   end
 
   @tag :admin
   test "disapprove", %{conn: conn, meta: meta} do
     {:ok, _} = MetaActions.submit_for_approval(meta)
+
+    notes = AdminUserNoteActions.list(for_meta: meta)
+    assert length(notes) == 0
 
     conn
     |> post(meta_path(conn, :disapprove, meta.id))
@@ -49,5 +60,8 @@ defmodule PlenarioWeb.Admin.Testing.MetaControllerTest do
 
     meta = MetaActions.get(meta.id)
     assert meta.state == "new"
+
+    notes = AdminUserNoteActions.list(for_meta: meta)
+    assert length(notes) == 1
   end
 end

--- a/test/plenario_web/controllers/web/admin_user_note_controller_test.exs
+++ b/test/plenario_web/controllers/web/admin_user_note_controller_test.exs
@@ -1,0 +1,23 @@
+defmodule PlenarioWeb.Web.Testing.AdminUserNoteControllerTest do
+  use PlenarioWeb.Testing.ConnCase, async: true
+
+  alias Plenario.Actions.MetaActions
+
+  alias PlenarioMailer.Actions.AdminUserNoteActions
+
+  setup %{admin_user: admin, reg_user: user} do
+    {:ok, meta} = MetaActions.create("name", user, "https://example.com/", "csv")
+    {:ok, note} = AdminUserNoteActions.create_for_meta(meta, admin, user, "this is a test", false)
+    {:ok, [note: note]}
+  end
+
+  @tag :auth
+  test "mark acknowledged", %{conn: conn, note: note} do
+    conn
+    |> post(admin_user_note_path(conn, :mark_acknowledged, note.id, redir: me_path(conn, :index)))
+    |> html_response(:found)
+
+    note = AdminUserNoteActions.get(note.id)
+    assert note.acknowledged
+  end
+end


### PR DESCRIPTION
This was kind of left in the dust during the `plenarex` merge.

- [x] retouch the schema, changesets and actions
- [x] test the email system
- [x] wire up notes on admin actions
- [x] display notes in _messages_ section of user home

Closes #167 