### PR TITLE
Load JSON Field Type

### DIFF
--- a/lib/model_registry.ex
+++ b/lib/model_registry.ex
@@ -8,7 +8,8 @@ defmodule Plenario.ModelRegistry do
     "integer" => :integer,
     "text" => :string,
     "date" => Plenario.ForgivingDatetime,
-    "timestamptz" => Plenario.ForgivingDatetime
+    "timestamptz" => Plenario.ForgivingDatetime,
+    "jsonb" => Plenario.Jsonb
   }
 
   @doc """

--- a/lib/plenario/schemas/data_set_field.ex
+++ b/lib/plenario/schemas/data_set_field.ex
@@ -11,7 +11,6 @@ defmodule Plenario.Schemas.DataSetField do
     "float",
     "boolean",
     "timestamptz",
-    "geometry",
     "jsonb"
   ]
 
@@ -21,7 +20,6 @@ defmodule Plenario.Schemas.DataSetField do
     Decimal: "float",
     "True/False": "boolean",
     Date: "timestamptz",
-    "Raw GIS Field": "geometry",
     JSON: "jsonb"
   ]
 

--- a/lib/postgres_extensions.ex
+++ b/lib/postgres_extensions.ex
@@ -125,3 +125,15 @@ defmodule Plenario.ForgivingDatetime do
     end
   end
 end
+
+defmodule Plenario.Jsonb do
+  @behaviour Ecto.Type
+
+  def type(), do: :jsonb
+
+  def cast(value), do: {:ok, value}
+
+  def load(value), do: {:ok, value}
+
+  def dump(value), do: {:ok, value}
+end

--- a/test/fixtures/embedded.json
+++ b/test/fixtures/embedded.json
@@ -1,0 +1,65 @@
+[
+  {
+    "node_id": "123abc",
+    "latitude": 41.55,
+    "longitude": -87.71,
+    "timestamp": "2018-01-01T10:00:05Z",
+    "tags": [
+      "Array of Things",
+      "Chicago"
+    ],
+    "observations": [
+      {
+        "sensor_id": "brd1",
+        "temperature": 2.13,
+        "relative_humidity": 77.3
+      },
+      {
+        "sensor_id": "brf2",
+        "vibration": 33.3
+      }
+    ]
+  },
+  {
+    "node_id": "124abc",
+    "latitude": 41.54,
+    "longitude": -87.72,
+    "timestamp": "2018-01-01T10:00:05Z",
+    "tags": [
+      "Array of Things",
+      "Chicago"
+    ],
+    "observations": [
+      {
+        "sensor_id": "brd1",
+        "temperature": 2.12,
+        "relative_humidity": 77.3
+      },
+      {
+        "sensor_id": "brf2",
+        "vibration": 32.9
+      }
+    ]
+  },
+  {
+    "node_id": "125abc",
+    "latitude": 41.53,
+    "longitude": -87.73,
+    "timestamp": "2018-01-01T10:00:05Z",
+    "tags": [
+      "Array of Things",
+      "Chicago"
+    ],
+    "observations": [
+      {
+        "sensor_id": "brd1",
+        "temperature": 2.2,
+        "relative_humidity": 76.8
+      },
+      {
+        "sensor_id": "brf2",
+        "vibration": 34.1
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- added a custom type to handle non-strict json
- added tests
- removed geometry type from dsf

We need this because `:map` is too strict. It doesn't allow arrays as
the top level data structure. Something like `{}` is fine, but `[{}]`
blows up.

Closes #173