### PR TITLE
Set Meta Attrs when ETL Job Completes

### DIFF
--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -87,18 +87,15 @@ defmodule Plenario.Actions.MetaActions do
   Convenience function for updating a Meta's next_import attribute.
   """
   @spec update_next_import(meta :: Meta) :: ok_instance
-  def update_next_import(meta) do
+  def update_next_import(%Meta{refresh_rate: nil, refresh_interval: nil} = meta), do: {:ok, meta}
+  def update_next_import(%Meta{refresh_rate: rate, refresh_interval: interval} = meta) do
     current =
       case meta.next_import do
         nil -> DateTime.utc_now()
-        _ -> meta.next_refresh
+        _ -> meta.next_import
       end
 
-    rate = meta.refresh_rate
-    interval = meta.refresh_interval
-
     shifted = Timex.shift(current, [{String.to_atom(rate), interval}])
-
     update(meta, next_import: shifted)
   end
 

--- a/lib/plenario/schemas/meta.ex
+++ b/lib/plenario/schemas/meta.ex
@@ -5,6 +5,8 @@ defmodule Plenario.Schemas.Meta do
 
   use Ecto.Schema
 
+  alias Plenario.Schemas.Meta
+
   use EctoStateMachine,
     states: [:new, :needs_approval, :awaiting_first_import, :ready, :erred],
     events: [
@@ -136,5 +138,10 @@ defmodule Plenario.Schemas.Meta do
     else
       "-"
     end
+  end
+
+  def get_time_range_string(%Meta{time_range: nil}), do: "-"
+  def get_time_range_string(%Meta{time_range: [lower, upper]}) do
+    "#{lower} to #{upper}"
   end
 end

--- a/lib/plenario_etl/etl_job_actions.ex
+++ b/lib/plenario_etl/etl_job_actions.ex
@@ -4,6 +4,8 @@ defmodule PlenarioEtl.Actions.EtlJobActions do
   underlying the various public interfaces for EtlJob.
   """
 
+  require Logger
+
   import Ecto.Query
 
 
@@ -90,10 +92,18 @@ defmodule PlenarioEtl.Actions.EtlJobActions do
     MetaActions.update_latest_import(meta, DateTime.utc_now())
     MetaActions.update_next_import(meta)
 
-    {lower, upper} = MetaActions.compute_time_range!(meta)
-    MetaActions.update_time_range(meta, lower, upper)
+    try do
+      {lower, upper} = MetaActions.compute_time_range!(meta)
+      MetaActions.update_time_range(meta, lower, upper)
+    rescue
+      e -> Logger.error("Tried to compute time range: #{inspect(e)}")
+    end
 
-    bbox = MetaActions.compute_bbox!(meta)
-    MetaActions.update_bbox(meta, bbox)
+    try do
+      bbox = MetaActions.compute_bbox!(meta)
+      MetaActions.update_bbox(meta, bbox)
+    rescue
+      e -> Logger.error("Tried to compute bbox: #{inspect(e)}")
+    end
   end
 end

--- a/lib/plenario_web/templates/web/data_set/show.html.eex
+++ b/lib/plenario_web/templates/web/data_set/show.html.eex
@@ -67,7 +67,7 @@
         </tr>
         <tr>
           <td>Time Range:</td>
-          <td><%= @meta.time_range || "-" %></td>
+          <td><%= Plenario.Schemas.Meta.get_time_range_string(@meta) %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
All this does is calls the respective MetaActions functions to compute
and set attributes on the Meta.

I also added a function to get a template friendly string for the time
range.

Closes #175