### PR TITLE
Better Maps and Search UX

### DIFF
--- a/lib/plenario_web/controllers/web/page_controller.ex
+++ b/lib/plenario_web/controllers/web/page_controller.ex
@@ -3,11 +3,25 @@ defmodule PlenarioWeb.Web.PageController do
 
   def index(conn, _), do: render(conn, "index.html")
 
-  def explorer(conn, _) do
-    render(conn, "explorer.html", map_center: "[41.9, -87.7]", bbox: nil, starts: "", ends: "")
+  def explorer(conn, params) do
+    zoom = Map.get(params, "zoom", nil)
+    coords = Map.get(params, "coords", nil)
+    starts = Map.get(params, "starting_on", nil)
+    ends = Map.get(params, "ending_on", nil)
+
+    do_explorer(zoom, coords, starts, ends, conn)
   end
 
-  def search_all_data_sets(conn, %{"coords" => coords, "starting_on" => starts, "ending_on" => ends} = params) do
+  defp do_explorer(nil, nil, nil, nil, conn) do
+    render(conn, "explorer.html",
+      map_center: "[41.9, -87.7]",
+      map_zoom: 10,
+      bbox: nil,
+      starts: "",
+      ends: ""
+    )
+  end
+  defp do_explorer(zoom, coords, starts, ends, conn) do
     coords = Poison.decode!(coords)
     bbox = build_polygon(coords)
 
@@ -25,6 +39,7 @@ defmodule PlenarioWeb.Web.PageController do
     render(conn, "explorer.html",
       results: results,
       map_center: get_poly_center(bbox),
+      map_zoom: zoom,
       bbox: "#{inspect(map_bbox)}",
       starts: starts,
       ends: ends)

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -43,7 +43,6 @@ defmodule PlenarioWeb.Router do
     # landing pages
     get "/", PageController, :index
     get "/explore", PageController, :explorer
-    post "/explore", PageController, :search_all_data_sets
     get "/explore/array-of-things", PageController, :aot_explorer
 
     # auth pages

--- a/lib/plenario_web/templates/shared/map.html.eex
+++ b/lib/plenario_web/templates/shared/map.html.eex
@@ -1,9 +1,8 @@
 <div id="<%= @map_id %>" style="height:<%= @map_height %>px"></div>
 
-
 <script defer>
-var map = L.map('<%= @map_id %>').setView(<%= @map_center %>, <%= @map_zoom %>);
-
+// instantiate the map
+let map = L.map('<%= @map_id %>').setView(<%= @map_center %>, <%= @map_zoom %>);
 L.tileLayer(
   'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
   {
@@ -14,15 +13,18 @@ L.tileLayer(
   }
 ).addTo(map);
 
-<%= if @draw_controls do %>
-var drawnItems = new L.FeatureGroup();
+// add layer for items drawn to map
+let drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 
-var drawControl = new L.Control.Draw({
+<%= if @draw_controls do %>
+// add the shape drawing controls to the map
+let drawControl = new L.Control.Draw({
   edit: {
     featureGroup: drawnItems
   },
   draw: {
+    polyline: false,
     circle: false,
     marker: false,
     circlemarker: false
@@ -30,16 +32,12 @@ var drawControl = new L.Control.Draw({
 });
 map.addControl(drawControl);
 
-var coordInput = document.getElementById('<%= @form_input_coords %>');
-var ciVal = coordInput.value;
-if (!ciVal.match(/^\[\[.*\]\]/)) {
-  coordInput.value = JSON.stringify(map.getBounds());
-}
-
-map.on('draw:created', function(e) {
-  var latLongs = e.layer.getLatLngs();
+// handle drawing events
+map.on('draw:created', function (e) {
+  let latLongs = e.layer.getLatLngs();
   latLongs = latLongs[0];
-  var coords = [];
+
+  let coords = [];
   for (var i = 0; i < latLongs.length; i++) {
     var el = latLongs[i];
     coords.push([
@@ -47,39 +45,50 @@ map.on('draw:created', function(e) {
       el.lng
     ]);
   }
-  var coordInput = document.getElementById('<%= @form_input_coords %>');
-  coordInput.value = JSON.stringify(coords);
 
+  let coordInput = document.getElementById('<%= @form_input_coords %>');
+  coordInput.value = JSON.stringify(coords);
   drawnItems.addLayer(e.layer);
 });
 
-map.on('draw:deleted', function(e) {
-  var coordInput = document.getElementById('<%= @form_input_coords %>');
+map.on('draw:deleted', function (e) {
+  let coordInput = document.getElementById('<%= @form_input_coords %>');
   coordInput.value = '';
-
   drawnItems.clearLayers(e.layer);
 });
 
-map.on('moveend', function(e) {
-  var coordInput = document.getElementById('<%= @form_input_coords %>');
-  var ciVal = coordInput.value;
-  if (!ciVal.match(/^\[\[.*\]\]/)) {
-    coordInput.value = JSON.stringify(map.getBounds());
+// setup form submit listener
+$('form:first').submit(function (e) {
+  let coordInput = document.getElementById('<%= @form_input_coords %>');
+  let zoomInput = document.getElementById('<%= @form_input_zoom %>');
+
+  if (!coordInput.value.match(/^\[\[.*\]\]/)) {
+    // set coords to entire map view and set zoom to 1 out
+    let bounds = map.getBounds();
+    coordInput.value = JSON.stringify(bounds);
+    zoomInput.value = map.getBoundsZoom(bounds, true) - 1;
+  } else {
+    // set zoom to current zoom
+    zoomInput.value = map.getZoom();
   }
+
+  return true;
 });
 <% end %>
 
 <%= if @bbox do %>
-L.polygon(<%= @bbox %>).addTo(map);
+let bbox = L.polygon(<%= @bbox %>).addTo(map);
+bbox.enable();
 <% end %>
 
 <%= if @points do %>
-var icon = L.icon({
+let icon = L.icon({
   iconUrl: '/images/marker-icon.png',
   shadowUrl: '/images/marker-shadow.png'
 });
-<%= for pt <- @points do %>
-L.marker(<%= pt %>, {icon: icon}).addTo(map);
+<%= for {pt, idx} <- Enum.with_index(@points) do %>
+let pt_<%= idx %> = L.marker(<%= pt %>, {icon: icon}).addTo(map);
+pt_<%= idx %>.enable();
 <% end %>
 <% end %>
 </script>

--- a/lib/plenario_web/templates/web/page/explorer.html.eex
+++ b/lib/plenario_web/templates/web/page/explorer.html.eex
@@ -7,7 +7,7 @@
     <h3>Select a Time</h3>
     <hr>
 
-    <%= form_for @conn, page_path(@conn, :search_all_data_sets), fn f -> %>
+    <%= form_for @conn, page_path(@conn, :explorer), [method: :get], fn f -> %>
 
     <div class="form-group">
       <label class="control-label">Starting On:</label>
@@ -21,6 +21,8 @@
 
     <input id="coords" name="coords" hidden>
 
+    <input id="zoom" name="zoom" hidden>
+
     <div class="form-group">
       <input type="submit" value="Search!" class="btn btn-primary">
     </div>
@@ -31,7 +33,7 @@
   <div class="col-lg-9">
     <h3>Select an Area</h3>
     <hr>
-    <%= PlenarioWeb.SharedView.render_map(draw_controls: true, map_center: @map_center, bbox: @bbox)%>
+    <%= PlenarioWeb.SharedView.render_map(draw_controls: true, map_center: @map_center, bbox: @bbox, map_zoom: @map_zoom)%>
   </div>
 </div>
 

--- a/lib/plenario_web/views/shared_view.ex
+++ b/lib/plenario_web/views/shared_view.ex
@@ -9,6 +9,7 @@ defmodule PlenarioWeb.SharedView do
       map_zoom: 10,
       draw_controls: false,
       form_input_coords: "coords",
+      form_input_zoom: "zoom",
       bbox: nil,
       points: nil
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/web/page_controller_test.exs
+++ b/test/plenario_web/controllers/web/page_controller_test.exs
@@ -28,7 +28,7 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
   end
 
   @tag :anon
-  test "search all data sets", %{conn: conn} do
+  test "search explorer", %{conn: conn} do
     {:ok, user} = UserActions.create("name", "email@example.com", "password")
     {:ok, meta1} = MetaActions.create("name 1", user, "https://example.com/1", "csv")
     {:ok, meta2} = MetaActions.create("name 2", user, "https://example.com/2", "csv")
@@ -107,11 +107,12 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
     params = %{
       "starting_on" => "2014-11-01",
       "ending_on" => "2015-11-01",
-      "coords" => "[[-30, -20], [-40, -50], [-10, -30], [-30, -20]]"
+      "coords" => "[[-30, -20], [-40, -50], [-10, -30], [-30, -20]]",
+      "zoom" => 10
     }
     response =
       conn
-      |> post(page_path(conn, :search_all_data_sets, params))
+      |> get(page_path(conn, :explorer, params))
       |> html_response(:ok)
 
     refute response =~ meta1.name
@@ -122,11 +123,12 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
     params = %{
       "starting_on" => "2016-11-01",
       "ending_on" => "2017-11-01",
-      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]"
+      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]",
+      "zoom" => 10
     }
     response =
       conn
-      |> post(page_path(conn, :search_all_data_sets, params))
+      |> get(page_path(conn, :explorer, params))
       |> html_response(:ok)
 
     assert response =~ meta1.name
@@ -137,11 +139,12 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
     params = %{
       "starting_on" => "2014-11-01",
       "ending_on" => "2015-11-01",
-      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]"
+      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]",
+      "zoom" => 10
     }
     response =
       conn
-      |> post(page_path(conn, :search_all_data_sets, params))
+      |> get(page_path(conn, :explorer, params))
       |> html_response(:ok)
 
     refute response =~ meta1.name


### PR DESCRIPTION
Let's start with maps:

- now persist bbox and zoom in a more intelligent way
- _much_ cleaner js

Improved search:

- set the form's inputs to correct values
- if the user doesn't set a bbox, the whole map is used
  and the zoom backs out to get a cleaner result map
- made search a `GET` request now, so people can share links

I also had to update a test and I bumped the version so we can deploy
this out.

Closes #186