### PR TITLE
Disable Edit Functions for Meta and Derivatives

### DIFF
--- a/lib/plenario_web/controllers/web/data_set_controller.ex
+++ b/lib/plenario_web/controllers/web/data_set_controller.ex
@@ -15,10 +15,27 @@ defmodule PlenarioWeb.Web.DataSetController do
   plug :authorize_resource, model: Meta
 
   def show(conn, %{"id" => id}) do
+    user = Guardian.Plug.current_resource(conn)
+
     meta = MetaActions.get(id, with_user: true, with_fields: true, with_constraints: true)
+
     virtual_dates = VirtualDateFieldActions.list(for_meta: meta, with_fields: true)
     virtual_points = VirtualPointFieldActions.list(for_meta: meta, with_fields: true)
-    render(conn, "show.html", meta: meta, virtual_dates: virtual_dates, virtual_points: virtual_points)
+
+    disabled? = meta.state != "new"
+    user_is_owner? =
+      case user do
+        nil -> false
+        _ -> user.id == meta.user_id
+      end
+
+    render(conn, "show.html",
+      meta: meta,
+      virtual_dates: virtual_dates,
+      virtual_points: virtual_points,
+      disabled?: disabled?,
+      user_is_owner?: user_is_owner?
+    )
   end
 
   def new(conn, _) do

--- a/lib/plenario_web/templates/web/data_set/show.html.eex
+++ b/lib/plenario_web/templates/web/data_set/show.html.eex
@@ -1,11 +1,11 @@
-<% is_owner = @current_user != nil and @current_user.id == @meta.user_id %>
+<% show_edits? = @user_is_owner? and !@disabled? %>
 
 <h2>
   <%= @meta.name %>
-  <%= if is_owner and @meta.state == "new" do %>
+  <%= if show_edits? do %>
     <%= button "Submit for Approval", to: data_set_path(@conn, :submit_for_approval, @meta.id), class: "btn btn-success pull-right" %>
   <% end %>
-  <%= if is_owner and not Enum.member?(["new", "needs_approval", "erred"], @meta.state) do %>
+  <%= if @user_is_owner? and not Enum.member?(["new", "needs_approval", "erred"], @meta.state) do %>
     <%= button "Ingest Now", to: data_set_path(@conn, :ingest_now, @meta.id), class: "btn btn-primary pull-right" %>
   <% end %>
 </h2>
@@ -16,7 +16,7 @@
   <div class="col-lg-6">
     <h3>
       General Info
-      <%= if is_owner do %>
+      <%= if show_edits? do %>
         <%= link "Edit", to: data_set_path(@conn, :edit, @meta.id), class: "btn btn-danger pull-right" %>
       <% end %>
     </h3>
@@ -91,7 +91,7 @@
         <tr>
           <th>Name</th>
           <th>Type</th>
-          <%= if is_owner do %><th></th><% end %>
+          <%= if show_edits? do %><th></th><% end %>
         </tr>
       </thead>
       <tbody>
@@ -99,7 +99,7 @@
         <tr>
           <td><%= f.name %></td>
           <td><%= f.type %></td>
-          <%= if is_owner do %><td><%= link "Edit", to: data_set_field_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
+          <%= if show_edits? do %><td><%= link "Edit", to: data_set_field_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
         <% end %>
       </tbody>
     </table>
@@ -107,7 +107,7 @@
   <div class="col-lg-6">
     <h3>
       Constraints
-      <%= if is_owner do %>
+      <%= if show_edits? do %>
         <%= link "Add a New Constraint", to: unique_constraint_path(@conn, :new, @meta.id), class: "btn btn-success pull-right" %>
       <% end %>
     </h3>
@@ -115,14 +115,14 @@
       <thead>
         <tr>
           <th>Unique Field Set</th>
-          <%= if is_owner do %><th></th><% end %>
+          <%= if show_edits? do %><th></th><% end %>
         </tr>
       </thead>
       <tbody>
         <%= for uc <- @meta.unique_constraints do %>
         <tr>
           <td><%= Enum.join(Plenario.Actions.UniqueConstraintActions.get_field_names(uc), ", ") %></td>
-          <%= if is_owner do %><td><%= link "Edit", to: unique_constraint_path(@conn, :edit, @meta.id, uc.id) %></td><% end %>
+          <%= if show_edits? do %><td><%= link "Edit", to: unique_constraint_path(@conn, :edit, @meta.id, uc.id) %></td><% end %>
         <% end %>
       </tbody>
     </table>
@@ -133,7 +133,7 @@
   <div class="col-lg-6">
     <h3>
       Computed Date Fields
-      <%= if is_owner do %>
+      <%= if show_edits? do %>
         <%= link "Add a New Date Field", to: virtual_date_path(@conn, :new, @meta.id), class: "btn btn-success pull-right" %>
       <% end %>
     </h3>
@@ -146,7 +146,7 @@
           <th>Hour Ref</th>
           <th>Minute Ref</th>
           <th>Second Ref</th>
-          <%= if is_owner do %><th></th><% end %>
+          <%= if show_edits? do %><th></th><% end %>
         </tr>
       </thead>
       <tbody>
@@ -158,7 +158,7 @@
           <td><%= if f.hour_field do %><%= f.hour_field.name %><% else %>-<% end %></td>
           <td><%= if f.minute_field do %><%= f.minute_field.name %><% else %>-<% end %></td>
           <td><%= if f.second_field do %><%= f.second_field.name %><% else %>-<% end %></td>
-          <%= if is_owner do %><td><%= link "Edit", to: virtual_date_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
+          <%= if show_edits? do %><td><%= link "Edit", to: virtual_date_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
         <% end %>
       </tbody>
     </table>
@@ -166,7 +166,7 @@
   <div class="col-lg-6">
     <h3>
       Computed Point Fields
-      <%= if is_owner do %>
+      <%= if show_edits? do %>
         <%= link "Add a New Point Field", to: virtual_point_path(@conn, :new, @meta.id), class: "btn btn-success pull-right" %>
       <% end %>
     </h3>
@@ -176,7 +176,7 @@
           <th>Location Ref</th>
           <th>Latitude Ref</th>
           <th>Longitude Ref</th>
-          <%= if is_owner do %><th></th><% end %>
+          <%= if show_edits? do %><th></th><% end %>
         </tr>
       </thead>
       <tbody>
@@ -185,7 +185,7 @@
           <td><%= if f.loc_field do %><%= f.loc_field.name %><% else %>-<% end %></td>
           <td><%= if f.lat_field do %><%= f.lat_field.name %><% else %>-<% end %></td>
           <td><%= if f.lon_field do %><%= f.lon_field.name %><% else %>-<% end %></td>
-          <%= if is_owner do %><td><%= link "Edit", to: virtual_point_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
+          <%= if show_edits? do %><td><%= link "Edit", to: virtual_point_path(@conn, :edit, @meta.id, f.id) %></td><% end %>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
When a meta is no longer _new_, we disable the buttons to edit it and do
any sort of CRUD work on its subordinate models.

The changesets already disallow these changes; this is more cosmetic
than anything.

Closes #166