### PR TITLE
Make `load_data` a synchronous process

### DIFF
--- a/lib/plenario_etl/worker.ex
+++ b/lib/plenario_etl/worker.ex
@@ -19,7 +19,6 @@ defmodule PlenarioEtl.Worker do
   require Logger
 
   @chunk_size Application.get_env(:plenario, PlenarioEtl)[:chunk_size]
-  @timeout 10000
 
   @doc """
   Entrypoint for the `Worker` `GenServer`. Saves you the hassle of writing out
@@ -43,11 +42,6 @@ defmodule PlenarioEtl.Worker do
   def handle_call({:load, meta_id_map}, _, state) do
     Logger.info("[#{inspect(self())}] [handle_call] Received :load call")
     {:reply, load(meta_id_map), state}
-  end
-
-  def handle_call({:load_chunk!, meta, job, chunk, constraints}, _, state) do
-    Logger.info("[#{inspect(self())}] [handle_call] Received :load_chunk! call")
-    {:reply, load_chunk!(meta, job, chunk, constraints), state}
   end
 
   @doc """
@@ -174,22 +168,7 @@ defmodule PlenarioEtl.Worker do
     decode.(path)
     |> Stream.chunk_every(@chunk_size)
     |> Enum.map(fn chunk ->
-      async_load_chunk!(meta, job, chunk, constraints)
-    end)
-    |> Enum.map(fn task ->
-      Task.await(task)
-    end)
-  end
-
-  def async_load_chunk!(meta, job, chunk, constraints) do
-    Task.async(fn ->
-      :poolboy.transaction(
-        :worker,
-        fn pid -> GenServer.call(pid, {:load_chunk!, meta, job, chunk, constraints}) end,
-        @timeout
-      )
-
-      {:ok, self()}
+      load_chunk!(meta, job, chunk, constraints) 
     end)
   end
 


### PR DESCRIPTION
```     
|> Enum.map(fn chunk ->
  async_load_chunk!(meta, job, chunk, constraints)
end)
|> Enum.map(fn task ->
  Task.await(task)
end)
```

This bit of code would spin up thousands of processes for datasets of significant sizes, most of which would time out because they either fail to checkout a poolboy connection or fail to checkout a database connection. They all die en masse and much stress ensues.

Closes #204 