### PR TITLE
Fixed Errors in Scheduler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :plenario, :s3_export_ttl, days: 5
 
 
 # configure quantum scheduler
-config :plenario, :refresh_offest, minutes: 1
+config :plenario, :refresh_offest, minutes: -1
 
 config :plenario, PlenarioEtl.Scheduler,
   global: true,

--- a/lib/plenario_etl/scheduled_jobs.ex
+++ b/lib/plenario_etl/scheduled_jobs.ex
@@ -1,22 +1,40 @@
 defmodule PlenarioEtl.ScheduledJobs do
-  alias Plenario.Schemas.Meta
-  alias Plenario.Repo
-
-  import Ecto.Query
-  import PlenarioEtl.Worker, only: [async_load!: 1]
 
   require Logger
 
+  import PlenarioEtl.Worker, only: [async_load!: 1]
+
+  alias Plenario.Actions.MetaActions
+
   def refresh_datasets() do
     offset = Application.get_env(:plenario, :refresh_offest)
-    starts = DateTime.utc_now()
-    ends = Timex.shift(starts, offset)
+    now = DateTime.utc_now()
+    last_check = Timex.shift(now, offset)
 
-    metas = Repo.all(
-      from m in Meta, where: m.next_import < ^starts
-    )
+    Logger.info("[#{inspect self()}] [refresh_datasets] time bounds: now=#{now} last_check=#{last_check}")
 
-    Logger.info("[#{inspect self()}] [refresh_datasets] Refreshing #{length(metas)} datasets")
+    all_metas =
+      MetaActions.list(only_ready: true)
+      |> Enum.reject(fn m ->
+        not is_nil(m.refresh_ends_on)
+        and Date.compare(m.refresh_ends_on, now) == :lt
+      end)
+
+    never_imported = Enum.filter(all_metas, fn m ->
+      not is_nil(m.refresh_rate)
+      and is_nil(m.next_import)
+    end)
+
+    ready_now = Enum.filter(all_metas, fn m ->
+      not is_nil(m.refresh_rate)
+      and not is_nil(m.next_import)
+      and Enum.member?([:gt, :ge], DateTime.compare(m.next_import, last_check))
+      and Enum.member?([:lt, :le], DateTime.compare(m.next_import, now))
+    end)
+
+    metas = never_imported ++ ready_now
+    names = for m <- metas, do: m.name
+    Logger.info("[#{inspect self()}] [refresh_datasets] Refreshing #{length(metas)} datasets: #{inspect(names)}")
 
     Enum.map(metas, fn meta ->
       async_load!(meta.id)

--- a/lib/plenario_etl/worker.ex
+++ b/lib/plenario_etl/worker.ex
@@ -243,8 +243,8 @@ defmodule PlenarioEtl.Worker do
   """
   @spec contains!(meta :: Meta, rows :: list[map], constraints :: list[atom]) :: Postgrex.Result
   def contains!(meta, rows, [constraint | _] = constraints) when is_atom(constraint) do
-    row_pks = 
-      for row <- rows do 
+    row_pks =
+      for row <- rows do
         for constraint <- constraints do
           row[constraint]
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_etl/scheduled_jobs_test.exs
+++ b/test/plenario_etl/scheduled_jobs_test.exs
@@ -27,12 +27,13 @@ defmodule PlentioEtl.Testing.ScheduledJobsTest do
         refresh_starts_on: Timex.shift(DateTime.utc_now(), years: -1),
         refresh_ends_on: nil,
         refresh_rate: "minutes",
-        refresh_interval: 1,
-        next_import: Timex.shift(DateTime.utc_now(), years: -1)
+        refresh_interval: 1
       )
+    {:ok, m} = MetaActions.submit_for_approval(meta)
+    {:ok, m} = MetaActions.approve(m)
+    {:ok, m} = MetaActions.mark_first_import(m)
 
-    MetaActions.update_next_import(meta)
-    good_meta = meta
+    good_meta = m
 
     {:ok, meta} =
       MetaActions.create("Some Old Dataset", user.id, "https://www.example.com/some-old-data-set", "csv")


### PR DESCRIPTION
**config.exs ->** the interval used put the search date a minute
into the future instead of the past

**scheduled_jobs.ex ->** the ecto query was getting really funky, so i
opted for getting all the ready metas, then filtering out the expired
refreshes, then finding unimported metas and those whose time was in the
range.

**scheduled_jobs_test.exs ->** had to update it to reflect the workflow