### PR TITLE
Export encodings

### DIFF
--- a/lib/encodings.ex
+++ b/lib/encodings.ex
@@ -1,0 +1,5 @@
+defimpl CSV.Encode, for: Map do
+  def encode(map, env \\ []) when is_map(map) do
+    Poison.encode!(map)
+  end
+end

--- a/lib/encodings.ex
+++ b/lib/encodings.ex
@@ -1,5 +1,5 @@
-defimpl CSV.Encode, for: Map do
-  def encode(map, env \\ []) when is_map(map) do
+defimpl String.Chars, for: Map do
+  def to_string(map) when is_map(map) do
     Poison.encode!(map)
   end
 end

--- a/lib/plenario_etl/actions/etl_job_actions.ex
+++ b/lib/plenario_etl/actions/etl_job_actions.ex
@@ -71,16 +71,23 @@ defmodule PlenarioEtl.Actions.EtlJobActions do
   end
 
   def mark_started(job) do
+    Logger.info("[#{inspect self()}] [mark_started] Marking etl job ##{job.id} as started...")
+
     EtlJobChangesets.mark_started(job)
     |> Repo.update()
   end
 
   def mark_erred(job, params = %{error_message: _}) do
+    Logger.info("[#{inspect self()}] [mark_erred] Marking etl job ##{job.id} as erred...")
+    Logger.error(params[:error_message])
+
     EtlJobChangesets.mark_erred(job, params)
     |> Repo.update()
   end
 
   def mark_completed(job) do
+    Logger.info("[#{inspect self()}] [mark_completed] Marking etl job ##{job.id} as completed...")
+    
     EtlJobChangesets.mark_completed(job)
     |> Repo.update()
 

--- a/lib/plenario_etl/actions/export_job_actions.ex
+++ b/lib/plenario_etl/actions/export_job_actions.ex
@@ -64,18 +64,24 @@ defmodule PlenarioEtl.Actions.ExportJobActions do
   end
 
   def mark_started(job) do
+    Logger.info("[#{inspect self()}] [mark_started] Marking export job ##{job.id} as started...")
+
     job
     |> ExportJob.mark_started()
     |> set_started_on()
   end
 
   def mark_completed(job) do
+    Logger.info("[#{inspect self()}] [mark_completed] Marking export job ##{job.id} as complete...")
+
     job
     |> ExportJob.mark_completed()
     |> set_completed_on()
   end
 
   def mark_erred(job, params) do
+    Logger.info("[#{inspect self()}] [mark_erred] Marking export job ##{job.id} as errored...")
+    
     job
     |> ExportJob.mark_erred()
     |> Changeset.cast(params, [:error_message])

--- a/lib/plenario_etl/worker.ex
+++ b/lib/plenario_etl/worker.ex
@@ -186,11 +186,12 @@ defmodule PlenarioEtl.Worker do
             GenServer.call(pid, {:load, %{
               meta_id: meta_id,
               job_id: job.id
-            }})
+            }}, :infinity)
             EtlJobActions.mark_completed(job)
           catch
-            :exit, code ->
-              EtlJobActions.mark_erred(job, %{error_message: inspect(code)})
+            :exit, message ->
+              Logger.error(inspect(message))
+              EtlJobActions.mark_erred(job, %{error_message: inspect(message)})
           end
         end,
         :infinity


### PR DESCRIPTION
- Fix error in encoding maps when exporting
- Set genserver call timeouts for Exporter and Worker to `:infinity`