### PR TITLE
Issue 231

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
   - mix do ecto.create, ecto.migrate
 
 script:
-  - mix coveralls.travis
+  - mix coveralls.travis --trace

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,15 @@
 use Mix.Config
 
+# Store the environment atom for situations where the `Mix` module is 
+# unavailable such as production or when compiling releases through
+# Exrm or Distillery. Any code looking to use the environment atom should
+# do so through `Application.get_env(:plenario, :env)`
+config :plenario, env: Mix.env()
+
 # Configure the database and application repo
-config :plenario, Plenario.Repo, types: Plenario.PostGisTypes
+config :plenario, Plenario.Repo, 
+  timeout: 30000,
+  types: Plenario.PostGisTypes
 
 config :plenario, ecto_repos: [Plenario.Repo]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,6 @@ config :plenario, env: Mix.env()
 
 # Configure the database and application repo
 config :plenario, Plenario.Repo, 
-  timeout: 30000,
   types: Plenario.PostGisTypes
 
 config :plenario, ecto_repos: [Plenario.Repo]

--- a/lib/field_guesser.ex
+++ b/lib/field_guesser.ex
@@ -66,7 +66,7 @@ defmodule Plenario.FieldGuesser do
   end
 
   defp download_async!(meta) do
-    {:ok, response} = HTTPoison.get(meta.source_url, %{}, stream_to: self)
+    {:ok, response} = HTTPoison.get(meta.source_url, %{}, stream_to: self())
     {:ok, messages} = receive_messages(response.id)
 
     messages
@@ -78,7 +78,7 @@ defmodule Plenario.FieldGuesser do
   end
 
   defp receive_messages(id, limit \\ 10), do: receive_messages(id, limit, [])
-  defp receive_messages(id, limit, acc) when length(acc) >= limit, do: {:ok, acc}
+  defp receive_messages(_id, limit, acc) when length(acc) >= limit, do: {:ok, acc}
   defp receive_messages(id, limit, acc) do
     receive do
       %HTTPoison.AsyncStatus{id: ^id, code: 200} ->
@@ -110,7 +110,7 @@ defmodule Plenario.FieldGuesser do
     |> Enum.take(count)
   end
 
-  defp parse!(filename, _, %Meta{source_type: "shp"}) do
+  defp parse!(_, _, %Meta{source_type: "shp"}) do
     []
   end
 
@@ -127,18 +127,18 @@ defmodule Plenario.FieldGuesser do
 
   def boolean?(value) when is_boolean(value), do: true
   def boolean?(value) when is_bitstring(value), do: Regex.match?(~r/^t$|^true$|^f$|^false$/i, value)
-  def boolean?(value), do: false
+  def boolean?(_), do: false
 
   def integer?(value) when is_integer(value), do: true
   def integer?(value) when is_bitstring(value), do: Regex.match?(~r/^-?\d+$/, value)
-  def integer?(value), do: false
+  def integer?(_), do: false
 
   def float?(value) when is_float(value), do: true
   def float?(value) when is_bitstring(value), do: Regex.match?(~r/^-?\d+\.\d+$/, value)
-  def float?(value), do: false
+  def float?(_), do: false
 
   def date?(value) when is_bitstring(value), do: Regex.match?(~r/\d{2,4}[-\/]\d{2}[-\/]\d{2,4}(.\d{1,2}:\d{1,2}:\d{1,2})?(.[ap]m)?/i, value)
-  def date?(value), do: false
+  def date?(_), do: false
 
   def json?(value) when is_map(value) or is_list(value), do: true
   def json?(value) when is_bitstring(value) do
@@ -147,5 +147,5 @@ defmodule Plenario.FieldGuesser do
       _ -> false
     end
   end
-  def json?(value), do: false
+  def json?(_), do: false
 end

--- a/lib/model_registry.ex
+++ b/lib/model_registry.ex
@@ -97,12 +97,12 @@ defmodule Plenario.ModelRegistry do
     {:reply, Map.fetch!(state, slug), state}
   end
 
-  def handle_cast(:clear, _) do
-    {:noreply, %{}}
-  end
-
   def handle_call(request, sender, state) do
     super(request, sender, state)
+  end
+
+  def handle_cast(:clear, _) do
+    {:noreply, %{}}
   end
 
   defp register(meta) do

--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -8,14 +8,9 @@ defmodule Plenario.Actions.MetaActions do
 
   import Ecto.Query
 
-  import Plenario.Queries.Utils
-
   alias Plenario.{Repo, ModelRegistry}
-
   alias Plenario.Schemas.{Meta, User}
-
   alias Plenario.Changesets.MetaChangesets
-
   alias Plenario.Queries.MetaQueries
 
   alias Plenario.Actions.{
@@ -331,8 +326,7 @@ defmodule Plenario.Actions.MetaActions do
     Repo.one(from m in model, select: fragment("count(*)"))
   end
 
-  def get_agg_data(meta, starts, ends) do
-    model = ModelRegistry.lookup(meta.slug)
+  def get_agg_data(meta, _starts, _ends) do
     fields = DataSetFieldActions.list(for_meta: meta)
 
     number_fields =
@@ -408,7 +402,7 @@ defmodule Plenario.Actions.MetaActions do
           data: data
         }
 
-      {:error, whatever} ->
+      {:error, _} ->
         %{
           labels: ["Uno", "Dos", "Tres", "Quattro", "Cinco", "Sies"],
           data: [{"Foo", [1,5,4,2,5,6]}, {"Bar", [2,3,1,5,6,5]}, {"Baz", [4,3,4,7,8,2]}]

--- a/lib/plenario/changesets/unique_constraint_changesets.ex
+++ b/lib/plenario/changesets/unique_constraint_changesets.ex
@@ -11,7 +11,7 @@ defmodule Plenario.Changesets.UniqueConstraintChangesets do
     set_random_name: 2
   ]
 
-  alias Plenario.Schemas.{UniqueConstraint, DataSetField}
+  alias Plenario.Schemas.UniqueConstraint
 
   alias Plenario.Actions.DataSetFieldActions
 
@@ -69,21 +69,20 @@ defmodule Plenario.Changesets.UniqueConstraintChangesets do
     meta_id = get_field(changeset, :meta_id)
     meta_fields = DataSetFieldActions.list(for_meta: meta_id)
     meta_field_ids =
-      Enum.reduce(meta_fields, HashSet.new(), fn f, acc ->
-        HashSet.put(acc, f.id)
+      Enum.reduce(meta_fields, MapSet.new(), fn f, acc ->
+        MapSet.put(acc, f.id)
       end)
 
     param_field_ids =
-      Enum.reduce(field_ids, HashSet.new(), fn id, acc ->
-        HashSet.put(acc, id)
+      Enum.reduce(field_ids, MapSet.new(), fn id, acc ->
+        MapSet.put(acc, id)
       end)
 
-    diff = HashSet.difference(param_field_ids, meta_field_ids)
-    changeset =
-      case HashSet.size(diff) > 0 do
-        true -> add_error(changeset, :field_ids, "Invalid field(s) selected")
-        false -> changeset
-      end
+    diff = MapSet.difference(param_field_ids, meta_field_ids)
+    case MapSet.size(diff) > 0 do
+      true -> add_error(changeset, :field_ids, "Invalid field(s) selected")
+      false -> changeset
+    end
   end
   defp validate_field_ids(changeset), do: changeset
 end

--- a/lib/plenario/schemas/unique_constraint.ex
+++ b/lib/plenario/schemas/unique_constraint.ex
@@ -18,7 +18,7 @@ defmodule Plenario.Schemas.UniqueConstraint do
     belongs_to :meta, Plenario.Schemas.Meta
   end
 
-  def get_field_choices(nil = param), do: [{}]
+  def get_field_choices(nil), do: [{}]
   def get_field_choices(%UniqueConstraint{meta_id: meta_id}), do: get_field_choices(meta_id)
   def get_field_choices(meta_id) do
     fields = DataSetFieldActions.list(for_meta: meta_id)

--- a/lib/plenario/schemas/virtual_date_field.ex
+++ b/lib/plenario/schemas/virtual_date_field.ex
@@ -23,7 +23,7 @@ defmodule Plenario.Schemas.VirtualDateField do
     belongs_to :second_field, Plenario.Schemas.DataSetField
   end
 
-  def get_field_choices(nil = param), do: [{}]
+  def get_field_choices(nil), do: [{}]
   def get_field_choices(%VirtualDateField{meta_id: meta_id}), do: get_field_choices(meta_id)
   def get_field_choices(meta_id) do
     fields = DataSetFieldActions.list(for_meta: meta_id)

--- a/lib/plenario/schemas/virtual_point_field.ex
+++ b/lib/plenario/schemas/virtual_point_field.ex
@@ -20,7 +20,7 @@ defmodule Plenario.Schemas.VirtualPointField do
     belongs_to :loc_field, Plenario.Schemas.DataSetField
   end
 
-  def get_field_choices(nil = param), do: [{}]
+  def get_field_choices(nil), do: [{}]
   def get_field_choices(%VirtualPointField{meta_id: meta_id}), do: get_field_choices(meta_id)
   def get_field_choices(meta_id) do
     fields = DataSetFieldActions.list(for_meta: meta_id)

--- a/lib/plenario_auth.ex
+++ b/lib/plenario_auth.ex
@@ -19,5 +19,5 @@ defmodule PlenarioAuth do
       true -> {:ok, user}
       false -> {:error, "Incorrect email or password"}
     end
-end
+  end
 end

--- a/lib/plenario_etl/actions/etl_job_actions.ex
+++ b/lib/plenario_etl/actions/etl_job_actions.ex
@@ -131,8 +131,6 @@ defmodule PlenarioEtl.Actions.EtlJobActions do
   end
 
   defp handle_error(error, _env) do
-    if not String.contains?(inspect(error), "__INTENTIONAL__") do
-      Logger.error("#{inspect(error)}")
-    end
+    Logger.error("#{inspect(error)}")
   end
 end

--- a/lib/plenario_etl/actions/export_job_actions.ex
+++ b/lib/plenario_etl/actions/export_job_actions.ex
@@ -23,9 +23,10 @@ defmodule PlenarioEtl.Actions.ExportJobActions do
   Creates a new instance of ExportJob
   """
   @spec create(meta :: Meta | integer, user :: User | integer, query :: String.t(), include_diffs :: boolean) :: ok_job
+  def create(meta, user, query, include_diffs \\ false)
   def create(meta, user, query, include_diffs) when not is_integer(meta), do: create(meta.id, user, query, include_diffs)
   def create(meta, user, query, include_diffs) when not is_integer(user), do: create(meta, user.id, query, include_diffs)
-  def create(meta, user, query, include_diffs \\ false) when is_integer(meta) and is_integer(user) do
+  def create(meta, user, query, include_diffs) when is_integer(meta) and is_integer(user) do
     params = %{
       meta_id: meta,
       user_id: user,

--- a/lib/plenario_etl/exporter.ex
+++ b/lib/plenario_etl/exporter.ex
@@ -79,7 +79,7 @@ defmodule PlenarioEtl.Exporter do
 
   defp generate_stream(job) do
     {query, _} = Code.eval_string(job.query)
-    Logger.info("[#{inspect(self())}] [generate_stream] Evaluating query: #{inspect query}")
+    Logger.info("Evaluating query: #{inspect query}")
     {job, stream(query)}
   end
 
@@ -87,7 +87,7 @@ defmodule PlenarioEtl.Exporter do
     path = "/tmp/#{inspect(uuid4())}"
     file = File.open!(path, [:write, :utf8])
 
-    Logger.info("[#{inspect(self())}] [stream_to_local_storage] Writing to #{path}")
+    Logger.info("Writing to #{path}")
     transaction(fn ->
       stream
       |> CSV.encode(headers: header(job.meta))
@@ -98,8 +98,8 @@ defmodule PlenarioEtl.Exporter do
   end
 
   defp upload_to_s3({job, path}) do
-    Logger.info("[#{inspect(self())}] [upload_to_s3] Uploading to bucket #{@bucket}")
-    Logger.info("[#{inspect(self())}] [upload_to_s3] At #{job.export_path}")
+    Logger.info("Uploading to bucket #{@bucket}")
+    Logger.info("At #{job.export_path}")
 
     path
     |> ExAws.S3.Upload.stream_file()
@@ -113,8 +113,8 @@ defmodule PlenarioEtl.Exporter do
     export_link = "https://s3.amazonaws.com/#{@bucket}/#{job.export_path}"
     target_email = job.user.email
 
-    Logger.info("[#{inspect(self())}] [send_email] Sending s3 link #{export_link}")
-    Logger.info("[#{inspect(self())}] [send_email] Sending link to #{target_email}")
+    Logger.info("Sending s3 link #{export_link}")
+    Logger.info("Sending link to #{target_email}")
 
     message = "Success! Your export results can be downloaded at: #{export_link}"
     email = Emails.send_email(target_email, message)
@@ -124,7 +124,7 @@ defmodule PlenarioEtl.Exporter do
 
   defp send_failure_email(job) do
     target_email = job.user.email
-    Logger.error("[#{inspect(self())}] [send_failure_email] Sending error to #{target_email}")
+    Logger.info("Sending error to #{target_email}")
     job = ExportJobActions.get!(job.id)
     email = Emails.send_email(target_email, job.error_message)
 
@@ -136,7 +136,7 @@ defmodule PlenarioEtl.Exporter do
   end
 
   def handle_info({:delivered_email, email}, state) do
-    Logger.info("[#{inspect(self())}] [PlenarioEtl.Exporter] Successfuly sent email #{inspect(email, pretty: true)}")
+    Logger.info("Successfuly sent email #{inspect(email, pretty: true)}")
     {:noreply, state}
   end
 end

--- a/lib/plenario_etl/worker.ex
+++ b/lib/plenario_etl/worker.ex
@@ -120,7 +120,7 @@ defmodule PlenarioEtl.Worker do
   defp load_tsv!(path, model, columns, constraints) do
     Logger.info("using tsv loader")
 
-    load!(model, path, columns, constraints, fn pth ->
+    load!(model, path, columns, constraints, fn _pth ->
       File.stream!(path)
       |> CSV.decode!(headers: true, separator: ?\t)
     end)
@@ -167,7 +167,7 @@ defmodule PlenarioEtl.Worker do
           _ -> :ok
         end
 
-        acc = acc ++ [res]
+        acc ++ [res]
       end)
 
     len_results = length(results)

--- a/lib/plenario_web/controllers/web/me_controller.ex
+++ b/lib/plenario_web/controllers/web/me_controller.ex
@@ -3,8 +3,6 @@ defmodule PlenarioWeb.Web.MeController do
 
   alias Plenario.Actions.{MetaActions, UserActions}
 
-  alias Plenario.Schemas.User
-
   alias PlenarioMailer.Actions.AdminUserNoteActions
 
   def index(conn, _) do
@@ -72,7 +70,7 @@ defmodule PlenarioWeb.Web.MeController do
                 |> put_flash(:success, "Password updated!")
                 |> redirect(to: me_path(conn, :index))
 
-              {:error, changeset} ->
+              {:error, _changeset} ->
                 conn
                 |> put_status(:bad_request)
                 |> put_flash(:error, "Invalid new password")

--- a/lib/plenario_web/templates/web/page/explorer.html.eex
+++ b/lib/plenario_web/templates/web/page/explorer.html.eex
@@ -7,7 +7,7 @@
     <h3>Select a Time</h3>
     <hr>
 
-    <%= form_for @conn, page_path(@conn, :explorer), [method: :get], fn f -> %>
+    <%= form_for @conn, page_path(@conn, :explorer), [method: :get], fn _f -> %>
 
     <div class="form-group">
       <label class="control-label">Starting On:</label>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.2.7",
+      version: "0.2.8",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario/data_set_actions_test.exs
+++ b/test/plenario/data_set_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.DataSetActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Repo
 

--- a/test/plenario/data_set_field_actions_test.exs
+++ b/test/plenario/data_set_field_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.DataSetFieldActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Actions.{DataSetFieldActions, MetaActions}
 

--- a/test/plenario/meta_actions_test.exs
+++ b/test/plenario/meta_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.MetaActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase
 
   import Mock
 

--- a/test/plenario/plenario_test.exs
+++ b/test/plenario/plenario_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.PlenarioTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario
 

--- a/test/plenario/unique_constraint_actions_test.exs
+++ b/test/plenario/unique_constraint_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.UniqueConstraintActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase
 
   alias Plenario.Actions.{DataSetFieldActions, UniqueConstraintActions}
 

--- a/test/plenario/user_actions_test.exs
+++ b/test/plenario/user_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.UserActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Actions.UserActions
 

--- a/test/plenario/virtual_date_field_actions_test.exs
+++ b/test/plenario/virtual_date_field_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.VirtualDateFieldActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Actions.{DataSetFieldActions, VirtualDateFieldActions}
 

--- a/test/plenario/virtual_point_field_actions_test.exs
+++ b/test/plenario/virtual_point_field_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Plenario.Testing.VirtualPointFieldActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Actions.{DataSetFieldActions, VirtualPointFieldActions}
 

--- a/test/plenario_auth/abilities_test.exs
+++ b/test/plenario_auth/abilities_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioAuth.Testing.AbilitiesTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase
 
   alias Plenario.Actions.{
     UserActions,

--- a/test/plenario_auth/admin_plug_test.exs
+++ b/test/plenario_auth/admin_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioAuth.Testing.AdminPlugTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   @tag :anon
   test "anonymous users cannot access admin routes", %{conn: conn} do

--- a/test/plenario_etl/etl_job_actions_test.exs
+++ b/test/plenario_etl/etl_job_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioEtl.Testing.EtlJobActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase
 
   alias PlenarioEtl.Actions.EtlJobActions
 

--- a/test/plenario_etl/exporter_test.exs
+++ b/test/plenario_etl/exporter_test.exs
@@ -30,14 +30,14 @@ defmodule PlenarioEtl.ExporterTest do
   end
 
   test "export/1 errs", %{export_job: job} do
-    with_mock ExAws, request!: fn _a, _b -> throw("Intentional Error") end do
+    with_mock ExAws, request!: fn _a, _b -> throw("__INTENTIONAL__") end do
       Exporter.export(job)
     end
 
     job = Repo.one!(from(e in ExportJob, where: e.id == ^job.id))
 
     assert job.state == "erred"
-    assert job.error_message =~ "Intentional Error"
+    assert job.error_message =~ "__INTENTIONAL__"
   end
 
   test "export/1 success email", context do
@@ -53,13 +53,13 @@ defmodule PlenarioEtl.ExporterTest do
   end
 
   test "export/1 err email", context do
-    with_mock ExAws, request!: fn _a, _b -> throw("Intentional Error") end do
+    with_mock ExAws, request!: fn _a, _b -> throw("__INTENTIONAL__") end do
       {_job, email} = Exporter.export(context.export_job)
 
       assert email.from == {nil, "plenario@uchicago.edu"}
       assert email.to == [nil: context.user.email]
       assert email.subject == "Plenario Notification"
-      assert email.text_body =~ "Intentional Error"
+      assert email.text_body =~ "__INTENTIONAL__"
       assert email.html_body == nil
     end
   end
@@ -72,7 +72,7 @@ defmodule PlenarioEtl.ExporterTest do
   end
 
   test "export/1 sends error email", context do
-    with_mock ExAws, request!: fn _a, _b -> throw("Intentional Error") end do
+    with_mock ExAws, request!: fn _a, _b -> throw("__INTENTIONAL__") end do
       {_job, email} = Exporter.export(context.export_job)
       assert_delivered_email(email)
     end

--- a/test/plenario_etl/scheduled_jobs_test.exs
+++ b/test/plenario_etl/scheduled_jobs_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioEtl.Testing.ScheduledJobsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case 
 
   alias Plenario.Actions.{MetaActions, UserActions}
 

--- a/test/plenario_etl/shapefile_test.exs
+++ b/test/plenario_etl/shapefile_test.exs
@@ -1,4 +1,4 @@
 defmodule PlenarioEtl.Testing.ShapefileTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case 
   doctest PlenarioEtl.Shapefile
 end

--- a/test/plenario_mailer/admin_user_note_actions_test.exs
+++ b/test/plenario_mailer/admin_user_note_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioMailer.Testing.AdminUserNoteActionsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias Plenario.Actions.UserActions
 

--- a/test/plenario_mailer/emails_test.exs
+++ b/test/plenario_mailer/emails_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioMailer.Testing.EmailsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias PlenarioMailer.Emails
 

--- a/test/plenario_web/controllers/admin/admin_page_controller_test.exs
+++ b/test/plenario_web/controllers/admin/admin_page_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Admin.Testing.AdminPageControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   @tag :admin
   test "index", %{conn: conn} do

--- a/test/plenario_web/controllers/admin/meta_controller_test.exs
+++ b/test/plenario_web/controllers/admin/meta_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Admin.Testing.MetaControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.MetaActions
 

--- a/test/plenario_web/controllers/admin/user_controller_test.exs
+++ b/test/plenario_web/controllers/admin/user_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Admin.Testing.UserControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase
 
   alias Plenario.Actions.UserActions
 

--- a/test/plenario_web/controllers/controller_utils_test.exs
+++ b/test/plenario_web/controllers/controller_utils_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Testing.ControllerUtilsTest do
-  use Plenario.Testing.DataCase, async: true
+  use Plenario.Testing.DataCase 
 
   alias PlenarioWeb.Controllers.Utils
 

--- a/test/plenario_web/controllers/controller_utils_test.exs
+++ b/test/plenario_web/controllers/controller_utils_test.exs
@@ -22,6 +22,6 @@ defmodule PlenarioWeb.Testing.ControllerUtilsTest do
 
   test "something that doesn't parse" do
     result = Utils.parse_date_string("whenever")
-    assert result = Timex.format!(Timex.today(), "{YYYY}-{0M}-{0D}")
+    assert ^result = Timex.format!(Timex.today(), "{YYYY}-{0M}-{0D}")
   end
 end

--- a/test/plenario_web/controllers/web/admin_user_note_controller_test.exs
+++ b/test/plenario_web/controllers/web/admin_user_note_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.AdminUserNoteControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.MetaActions
 

--- a/test/plenario_web/controllers/web/auth_test.exs
+++ b/test/plenario_web/controllers/web/auth_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.AuthControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   describe "index" do
     @tag :auth

--- a/test/plenario_web/controllers/web/data_set_controller_test.exs
+++ b/test/plenario_web/controllers/web/data_set_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.DataSetControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.MetaActions
 

--- a/test/plenario_web/controllers/web/data_set_field_controller_test.exs
+++ b/test/plenario_web/controllers/web/data_set_field_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.DataSetFieldControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.{MetaActions, DataSetFieldActions}
 

--- a/test/plenario_web/controllers/web/unique_constraint_controller_test.exs
+++ b/test/plenario_web/controllers/web/unique_constraint_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.UniqueConstraintControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.{
     MetaActions,

--- a/test/plenario_web/controllers/web/virtual_date_controller_test.exs
+++ b/test/plenario_web/controllers/web/virtual_date_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.VirtualDateControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.{
     MetaActions,

--- a/test/plenario_web/controllers/web/virtual_point_controller_test.exs
+++ b/test/plenario_web/controllers/web/virtual_point_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Web.Testing.VirtualPointControllerTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   alias Plenario.Actions.{
     MetaActions,

--- a/test/plenario_web/views/error_view_test.exs
+++ b/test/plenario_web/views/error_view_test.exs
@@ -1,5 +1,5 @@
 defmodule PlenarioWeb.Testing.ErrorViewTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View

--- a/test/plenario_web/views/layout_view_test.exs
+++ b/test/plenario_web/views/layout_view_test.exs
@@ -1,3 +1,3 @@
 defmodule PlenarioWeb.Testing.LayoutViewTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 end

--- a/test/plenario_web/views/page_view_test.exs
+++ b/test/plenario_web/views/page_view_test.exs
@@ -1,3 +1,3 @@
 defmodule PlenarioWeb.Testing.PageViewTest do
-  use PlenarioWeb.Testing.ConnCase, async: true
+  use PlenarioWeb.Testing.ConnCase 
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -37,6 +37,7 @@ defmodule PlenarioWeb.Testing.ConnCase do
   setup tags do
     # sandbox the db connection
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Plenario.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Plenario.Repo, {:shared, self()})
 
     # create an admin user
     {:ok, admin_user} = UserActions.create("Admin User", "admin@example.com", "password")
@@ -44,10 +45,6 @@ defmodule PlenarioWeb.Testing.ConnCase do
 
     # create a regular user
     {:ok, reg_user} = UserActions.create("Regular User", "regular@example.com", "password")
-
-    unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Plenario.Repo, {:shared, self()})
-    end
 
     # setup connection
     conn_ = Phoenix.ConnTest.build_conn()

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -27,8 +27,9 @@ defmodule Plenario.Testing.DataCase do
     end
   end
 
-  setup tags do
+  setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Plenario.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Plenario.Repo, {:shared, self()})
 
     # create a user
     {:ok, user} = UserActions.create("Test User", "test@example.com", "password")
@@ -41,10 +42,6 @@ defmodule Plenario.Testing.DataCase do
         "https://www.example.com/chicago-tree-trimming",
         "csv"
       )
-
-    unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Plenario.Repo, {:shared, self()})
-    end
 
     {
       :ok,


### PR DESCRIPTION
- Address all compiler warnings
- Prevent sentry from sending errors in environments other than `:prod`
- Set all tests to shared, synchronous mode

With the exception of intentional errors, the tests are no longer so noisy. As things progress we should selectively re-enable `:async` mode for certain test cases. But the ownership errors were happening mostly as a result of interactions between quantum/model registry and the database. Both of these processes are involved in many parts of the tests.