### PR TITLE
V2 endpoints

### DIFF
--- a/lib/plenario_web.ex
+++ b/lib/plenario_web.ex
@@ -46,7 +46,7 @@ defmodule PlenarioWeb do
 
   def api_controller do
     quote do
-      use Phoenix.Controller, namespece: PlenarioWeb.Api
+      use Phoenix.Controller, namespace: PlenarioWeb.Api
       import Plug.Conn
       import Canary.Plugs
     end
@@ -110,6 +110,7 @@ defmodule PlenarioWeb do
   def api_view do
     quote do
       use Phoenix.View,
+        root: "lib/plenario_web/templates/api",
         namespace: PlenarioWeb.Api
       import Phoenix.Controller, only: [view_module: 1]
       import PlenarioWeb.Router.Helpers

--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -9,7 +9,7 @@ defmodule PlenarioWeb.Api.AotController do
     render(conn, "head.json", %{})
   end
 
-  def options(conn, _params) do
-    render(conn, "options.json", %{})
+  def describe(conn, _params) do
+    render(conn, "describe.json", %{})
   end
 end

--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -1,0 +1,15 @@
+defmodule PlenarioWeb.Api.AotController do
+  use PlenarioWeb, :api_controller
+
+  def get(conn, _params) do
+    render(conn, "get.json", %{})
+  end
+
+  def head(conn, _params) do
+    render(conn, "head.json", %{})
+  end
+
+  def options(conn, _params) do
+    render(conn, "options.json", %{})
+  end
+end

--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -1,0 +1,15 @@
+defmodule PlenarioWeb.Api.DetailController do
+  use PlenarioWeb, :api_controller
+
+  def get(conn, _params) do
+    render(conn, "get.json", %{})
+  end
+
+  def head(conn, _params) do
+    render(conn, "head.json", %{})
+  end
+
+  def options(conn, _params) do
+    render(conn, "options.json", %{})
+  end
+end

--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -9,7 +9,7 @@ defmodule PlenarioWeb.Api.DetailController do
     render(conn, "head.json", %{})
   end
 
-  def options(conn, _params) do
-    render(conn, "options.json", %{})
+  def describe(conn, _params) do
+    render(conn, "describe.json", %{})
   end
 end

--- a/lib/plenario_web/controllers/api/list_controller.ex
+++ b/lib/plenario_web/controllers/api/list_controller.ex
@@ -2,17 +2,14 @@ defmodule PlenarioWeb.Api.ListController do
   use PlenarioWeb, :api_controller
 
   def get(conn, _params) do
-    IO.inspect("[ListController] [get]")
     render(conn, "get.json", %{})
   end
 
   def head(conn, _params) do
-    IO.inspect("[ListController] [HEAD]")
     render(conn, "head.json", %{})
   end
 
-  def options(conn, _params) do
-    IO.inspect("[ListController] [options]")
-    render(conn, "options.json", %{})
+  def describe(conn, _params) do
+    render(conn, "describe.json", %{})
   end
 end

--- a/lib/plenario_web/controllers/api/list_controller.ex
+++ b/lib/plenario_web/controllers/api/list_controller.ex
@@ -1,0 +1,18 @@
+defmodule PlenarioWeb.Api.ListController do
+  use PlenarioWeb, :api_controller
+
+  def get(conn, _params) do
+    IO.inspect("[ListController] [get]")
+    render(conn, "get.json", %{})
+  end
+
+  def head(conn, _params) do
+    IO.inspect("[ListController] [HEAD]")
+    render(conn, "head.json", %{})
+  end
+
+  def options(conn, _params) do
+    IO.inspect("[ListController] [options]")
+    render(conn, "options.json", %{})
+  end
+end

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -102,17 +102,17 @@ defmodule PlenarioWeb.Router do
   scope "/api/v2", PlenarioWeb.Api do
     pipe_through [:api]
 
-    # get "/data-sets", ListController, :get
-    head "/data-sets", ListController, :head
-    # options "/data-sets", ListController, :options
+    get "/data-sets", ListController, :get
+    get "/data-sets/@head", ListController, :head
+    get "/data-sets/@describe", ListController, :describe
 
     get "/detail", DetailController, :get
-    head "/detail", DetailController, :head
-    options "/detail", DetailController, :options
+    get "/detail/@head", DetailController, :head
+    get "/detail/@describe", DetailController, :describe
 
     get "/aot", AotController, :get
-    head "/aot", AotController, :head
-    options "/aot", AotController, :options
+    get "/aot/@head", AotController, :head
+    get "/aot/@describe", AotController, :describe
   end
 end
 

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -99,8 +99,20 @@ defmodule PlenarioWeb.Router do
 
   ##
   # api paths
-  scope "/api", PlenarioWeb.Api do
+  scope "/api/v2", PlenarioWeb.Api do
     pipe_through [:api]
+
+    # get "/data-sets", ListController, :get
+    head "/data-sets", ListController, :head
+    # options "/data-sets", ListController, :options
+
+    get "/detail", DetailController, :get
+    head "/detail", DetailController, :head
+    options "/detail", DetailController, :options
+
+    get "/aot", AotController, :get
+    head "/aot", AotController, :head
+    options "/aot", AotController, :options
   end
 end
 

--- a/lib/plenario_web/views/api/aot_view.ex
+++ b/lib/plenario_web/views/api/aot_view.ex
@@ -9,7 +9,7 @@ defmodule PlenarioWeb.Api.AotView do
     %{}
   end
 
-  def render("options.json", _params) do
+  def render("describe.json", _params) do
     %{}
   end
 end

--- a/lib/plenario_web/views/api/aot_view.ex
+++ b/lib/plenario_web/views/api/aot_view.ex
@@ -1,0 +1,15 @@
+defmodule PlenarioWeb.Api.AotView do
+  use PlenarioWeb, :api_view
+
+  def render("get.json", _params) do
+    %{}
+  end
+
+  def render("head.json", _params) do
+    %{}
+  end
+
+  def render("options.json", _params) do
+    %{}
+  end
+end

--- a/lib/plenario_web/views/api/detail_view.ex
+++ b/lib/plenario_web/views/api/detail_view.ex
@@ -1,0 +1,15 @@
+defmodule PlenarioWeb.Api.DetailView do
+  use PlenarioWeb, :api_view
+
+  def render("get.json", _params) do
+    %{}
+  end
+
+  def render("head.json", _params) do
+    %{foo: "BAR"}
+  end
+
+  def render("options.json", _params) do
+    %{}
+  end
+end

--- a/lib/plenario_web/views/api/detail_view.ex
+++ b/lib/plenario_web/views/api/detail_view.ex
@@ -6,10 +6,10 @@ defmodule PlenarioWeb.Api.DetailView do
   end
 
   def render("head.json", _params) do
-    %{foo: "BAR"}
+    %{}
   end
 
-  def render("options.json", _params) do
+  def render("describe.json", _params) do
     %{}
   end
 end

--- a/lib/plenario_web/views/api/list_view.ex
+++ b/lib/plenario_web/views/api/list_view.ex
@@ -6,10 +6,10 @@ defmodule PlenarioWeb.Api.ListView do
   end
 
   def render("head.json", _params) do
-    %{foo: "bar"}
+    %{}
   end
 
-  def render("options.json", _params) do
+  def render("describe.json", _params) do
     %{}
   end
 end

--- a/lib/plenario_web/views/api/list_view.ex
+++ b/lib/plenario_web/views/api/list_view.ex
@@ -1,0 +1,15 @@
+defmodule PlenarioWeb.Api.ListView do
+  use PlenarioWeb, :api_view
+
+  def render("get.json", _params) do
+    %{}
+  end
+
+  def render("head.json", _params) do
+    %{foo: "bar"}
+  end
+
+  def render("options.json", _params) do
+    %{}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -6,13 +6,13 @@ defmodule PlenarioWeb.Api.AotControllerTest do
     assert json_response(conn, 200) == %{}
   end
 
-  test "HEAD /api/v2/aot", %{conn: conn} do
-    conn = head(conn, "/api/v2/aot")
+  test "GET /api/v2/aot/@head", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot/@head")
     assert json_response(conn, 200) == %{}
   end
 
-  test "OPTIONS /api/v2/aot", %{conn: conn} do
-    conn = options(conn, "/api/v2/aot")
+  test "GET /api/v2/aot/@describe", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot/@describe")
     assert json_response(conn, 200) == %{}
   end
 end

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule PlenarioWeb.Api.AotControllerTest do
+  use PlenarioWeb.Testing.ConnCase
+
+  test "GET /api/v2/aot", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "HEAD /api/v2/aot", %{conn: conn} do
+    conn = head(conn, "/api/v2/aot")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "OPTIONS /api/v2/aot", %{conn: conn} do
+    conn = options(conn, "/api/v2/aot")
+    assert json_response(conn, 200) == %{}
+  end
+end

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule PlenarioWeb.Api.DetailControllerTest do
+  use PlenarioWeb.Testing.ConnCase
+
+  test "GET /api/v2/detail", %{conn: conn} do
+    conn = get(conn, "/api/v2/detail")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "HEAD /api/v2/detail", %{conn: conn} do
+    conn = head(conn, "/api/v2/detail")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "OPTIONS /api/v2/detail", %{conn: conn} do
+    conn = options(conn, "/api/v2/detail")
+    assert json_response(conn, 200) == %{}
+  end
+end

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -6,13 +6,13 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
     assert json_response(conn, 200) == %{}
   end
 
-  test "HEAD /api/v2/detail", %{conn: conn} do
-    conn = head(conn, "/api/v2/detail")
+  test "GET /api/v2/detail/@head", %{conn: conn} do
+    conn = get(conn, "/api/v2/detail/@head")
     assert json_response(conn, 200) == %{}
   end
 
-  test "OPTIONS /api/v2/detail", %{conn: conn} do
-    conn = options(conn, "/api/v2/detail")
+  test "GET /api/v2/detail/@describe", %{conn: conn} do
+    conn = get(conn, "/api/v2/detail/@describe")
     assert json_response(conn, 200) == %{}
   end
 end

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -6,13 +6,13 @@ defmodule PlenarioWeb.Api.ListControllerTest do
     assert json_response(conn, 200) == %{}
   end
 
-  test "HEAD /api/v2/data-sets", %{conn: conn} do
-    conn = head(conn, "/api/v2/data-sets")
+  test "GET /api/v2/data-sets/@head", %{conn: conn} do
+    conn = get(conn, "/api/v2/data-sets")
     assert json_response(conn, 200) == %{}
   end
 
-  test "OPTIONS /api/v2/data-sets", %{conn: conn} do
-    conn = options(conn, "/api/v2/data-sets")
+  test "GET /api/v2/data-sets/@describe", %{conn: conn} do
+    conn = get(conn, "/api/v2/data-sets")
     assert json_response(conn, 200) == %{}
   end
 end

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule PlenarioWeb.Api.ListControllerTest do
+  use PlenarioWeb.Testing.ConnCase
+
+  test "GET /api/v2/data-sets", %{conn: conn} do
+    conn = get(conn, "/api/v2/data-sets")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "HEAD /api/v2/data-sets", %{conn: conn} do
+    conn = head(conn, "/api/v2/data-sets")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "OPTIONS /api/v2/data-sets", %{conn: conn} do
+    conn = options(conn, "/api/v2/data-sets")
+    assert json_response(conn, 200) == %{}
+  end
+end


### PR DESCRIPTION
- Close #274
- Adds routes for new API
- Instead of OPTIONS and HEAD, routes are set up with special `@` endpoints
- Need to update the wiki to reflect this
- Tested em
