### PR TITLE
Slug endpoint

### DIFF
--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -1,15 +1,29 @@
 defmodule PlenarioWeb.Api.DetailController do
   use PlenarioWeb, :api_controller
 
-  def get(conn, _params) do
-    render(conn, "get.json", %{})
+  alias Plenario.ModelRegistry
+  alias Plenario.Repo
+
+  import Ecto.Query
+
+  def get(conn, %{"slug" => slug}) do
+    records =
+      from(r in ModelRegistry.lookup(slug), limit: 500)
+      |> Repo.all()
+    render(conn, "get.json", %{records: records})
   end
 
-  def head(conn, _params) do
-    render(conn, "head.json", %{})
+  def head(conn, %{"slug" => slug}) do
+    record =
+      first(ModelRegistry.lookup(slug))
+      |> Repo.one()
+    render(conn, "head.json", %{record: record})
   end
 
-  def describe(conn, _params) do
-    render(conn, "describe.json", %{})
+  def describe(conn, %{"slug" => slug}) do
+    records =
+      from(r in ModelRegistry.lookup(slug), limit: 500)
+      |> Repo.all()
+    render(conn, "describe.json", %{records: records})
   end
 end

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -109,9 +109,9 @@ defmodule PlenarioWeb.Router do
     get "/data-sets/@head", ListController, :head
     get "/data-sets/@describe", ListController, :describe
 
-    get "/detail", DetailController, :get
-    get "/detail/@head", DetailController, :head
-    get "/detail/@describe", DetailController, :describe
+    get "/data-sets/:slug", DetailController, :get
+    get "/data-sets/:slug/@head", DetailController, :head
+    get "/data-sets/:slug/@describe", DetailController, :describe
 
     get "/aot", AotController, :get
     get "/aot/@head", AotController, :head

--- a/lib/plenario_web/views/api/detail_view.ex
+++ b/lib/plenario_web/views/api/detail_view.ex
@@ -1,15 +1,18 @@
+alias PlenarioWeb.Api.Response
+
+
 defmodule PlenarioWeb.Api.DetailView do
   use PlenarioWeb, :api_view
 
-  def render("get.json", _params) do
-    %{}
+  def render("get.json", %{records: records}) do
+    %Response{data: records}
   end
 
-  def render("head.json", _params) do
-    %{}
+  def render("head.json", %{record: record}) do
+    %Response{data: record}
   end
 
-  def render("describe.json", _params) do
-    %{}
+  def render("describe.json", %{records: records}) do
+    %Response{data: records}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.6.1",
+      version: "0.6.2",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -1,18 +1,3 @@
 defmodule PlenarioWeb.Api.DetailControllerTest do
   use PlenarioWeb.Testing.ConnCase
-
-  test "GET /api/v2/detail", %{conn: conn} do
-    conn = get(conn, "/api/v2/detail")
-    assert json_response(conn, 200) == %{}
-  end
-
-  test "GET /api/v2/detail/@head", %{conn: conn} do
-    conn = get(conn, "/api/v2/detail/@head")
-    assert json_response(conn, 200) == %{}
-  end
-
-  test "GET /api/v2/detail/@describe", %{conn: conn} do
-    conn = get(conn, "/api/v2/detail/@describe")
-    assert json_response(conn, 200) == %{}
-  end
 end


### PR DESCRIPTION
- Bump to version `0.6.2`
- Return raw data for `/data-sets/:slug` endpoints
- I haven't done anything special for `@describe` because I'm not sure what that means in the context for raw data
- I also haven't written tests for these responses (forgive me), I'm going to make an issue and open a testing branch after the aot endpoints are filled out
- Close #276 

```
{
  "meta": {
    "params": {
      "page_size": 500
    },
    "links": {
      "previous": "",
      "next": "",
      "current": ""
    },
    "counts": {
      "total_records": 0,
      "pages": 0,
      "errors": 0,
      "data": 0
    }
  },
  "data": [
    {
      "__meta__": {
        "state": "loaded",
        "source": [
          null,
          "ds_9y-E2jFcCZPRG68W"
        ],
        "context": null
      },
      "Street 1": "11207 S. Ewing",
      "State": "IL",
      "Postal Code": 60617,
      "Phone": "(773) 721-1999",
      "Longitude": -87.5351333203,
      "Latitude": 41.6915835405,
      "Facility Type": "Alderman",
      "Facility Name": "10th Ward-Knights of Columbus",
      "End Time": "3pm",
      "Date": "2013-10-25T00:00:00",
      "City": "Chicago",
      "Begin Time": "9am"
    }
```