### PR TITLE
Remove `to_naive_datetime/1`

### DIFF
--- a/lib/plenario_web/controllers/api/parse_column_params.ex
+++ b/lib/plenario_web/controllers/api/parse_column_params.ex
@@ -1,6 +1,5 @@
 defmodule PlenarioWeb.Controllers.Api.ParseColumnParams do
   use PlenarioWeb, :api_controller
-  import PlenarioWeb.Api.Utils, only: [to_naive_datetime: 1]
   alias Plenario.Actions.MetaActions
 
   def init(default) do

--- a/lib/plenario_web/controllers/api/parse_db_operation_params.ex
+++ b/lib/plenario_web/controllers/api/parse_db_operation_params.ex
@@ -1,6 +1,5 @@
 defmodule PlenarioWeb.Api.ParseDbOperationParams do
   use PlenarioWeb, :api_controller
-  import PlenarioWeb.Api.Utils, only: [to_naive_datetime: 1]
 
   @db_operation_keys ["updated_at", "inserted_at"]
 
@@ -14,8 +13,7 @@ defmodule PlenarioWeb.Api.ParseDbOperationParams do
       |> Map.split(@db_operation_keys)
 
     params = Enum.map(params, fn {key, value} ->
-      [operator, datetime_str] = String.split(value, ":", parts: 2)
-      {:ok, datetime} = to_naive_datetime(datetime_str)
+      [operator, datetime] = String.split(value, ":", parts: 2)
       {key, {operator, datetime}}
     end)
 

--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -144,8 +144,8 @@ defmodule PlenarioWeb.Api.Utils do
   ## Examples
 
       iex> params = %{
-      ...>   "Inserted At" => {"le", ~N[2000-01-01 13:30:15]},
-      ...>   "updated_at" => {"lt", ~N[2000-01-01 13:30:15]},
+      ...>   "Inserted At" => {"le", "2000-01-01 13:30:15"},
+      ...>   "updated_at" => {"lt", "2000-01-01 13:30:15"},
       ...>   "Float Column" => {"ge", 0.0},
       ...>   "integer_column" => {"gt", 42},
       ...>   "String Column" => {"eq", "hello!"}
@@ -157,35 +157,5 @@ defmodule PlenarioWeb.Api.Utils do
   def map_to_query(query, params) when is_map(params), do: map_to_query(query, Map.to_list(params))
   def map_to_query(query, [condition_tuple | params]) do
     map_to_query(query |> where_condition(condition_tuple), params)
-  end
-
-  @doc """
-  Attempts to derive a datetime from a string. The string can specify a date or
-  a datetime, and the function will produce a naive datetime. If it fails to
-  parse a datetime, it will return a tuple specifying the error.
-
-  ## Examples
-
-      iex> to_naive_datetime("2000-01-01")
-      {:ok, datetime}
-
-      iex> to_naive_datetime("2000-01-01T00:00:00")
-      {:ok, datetime}
-
-      iex> to_naive_datetime("nani")
-      {:error, message}
-
-  """
-  def to_naive_datetime(string) do
-    case Date.from_iso8601(string) do
-      {:ok, date} ->
-        date_erl = Date.to_erl(date)
-        {:ok, NaiveDateTime.from_erl!({date_erl}, {0, 0, 0})}
-      {:error, _} ->
-        case NaiveDateTime.from_iso8601(string) do
-          {:ok, datetime} -> {:ok, datetime}
-          {:error, message, _} -> {:error, message}
-        end
-    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.7.1",
+      version: "0.7.3",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
- Remove an unnecessary function
- Ecto casts values provided for queries on its own
- Bump to version 0.7.3