### PR TITLE
AoT API - Part 1

### DIFF
--- a/lib/plenario_aot/aot_data.ex
+++ b/lib/plenario_aot/aot_data.ex
@@ -5,6 +5,7 @@ defmodule PlenarioAot.AotData do
 
   alias PlenarioAot.AotData
 
+  @derive [Poison.Encoder]
   schema "aot_data" do
     field :aot_meta_id, :id
     field :node_id, :string

--- a/lib/plenario_aot/aot_meta.ex
+++ b/lib/plenario_aot/aot_meta.ex
@@ -3,8 +3,9 @@ defmodule PlenarioAot.AotMeta do
 
   import Ecto.Changeset
 
-  alias PlenarioAot.AotMeta
+  alias PlenarioAot.{AotData, AotMeta}
 
+  @derive [Poison.Encoder]
   schema "aot_metas" do
     field :network_name, :string
     field :slug, :string
@@ -12,6 +13,8 @@ defmodule PlenarioAot.AotMeta do
     field :bbox, Geo.Polygon
     field :time_range, Plenario.TsTzRange
     timestamps()
+
+    has_many :data, AotData
   end
 
   def changeset(meta \\ %AotMeta{}, params \\ []) do

--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -1,29 +1,204 @@
 defmodule PlenarioWeb.Api.AotController do
   use PlenarioWeb, :api_controller
-  alias Plenario.Actions.MetaActions
-  alias PlenarioWeb.Controllers.Api.CaptureArgs
 
-  @slug "array-of-things-chicago"
-  @params %{"slug" => @slug}
+  import Ecto.Query
 
-  defmodule CaptureColumnArgs do
-    @slug "array-of-things-chicago"
+  import Geo.PostGIS, only: [st_intersects: 2]
 
-    def init(opts), do: opts
+  import PlenarioWeb.Api.Utils, only: [render_page: 5]
 
-    def call(conn, opts) do
-      columns = MetaActions.get_column_names(MetaActions.get(@slug))
-      CaptureArgs.call(conn, opts ++ [fields: columns])
+  alias Plenario.Repo
+
+  alias PlenarioAot.{AotData, AotMeta, AotObservation}
+
+  require Logger
+
+  require IEx
+
+  defp parse_bbox(value) do
+    try do
+      Poison.decode!(value) |> Geo.JSON.decode()
+    rescue
+      _ -> nil
     end
   end
 
-  plug(CaptureArgs, assign: :geospatial_fields, fields: ["bbox"])
-  plug(CaptureArgs, assign: :ordering_fields, fields: ["order_by"])
-  plug(CaptureArgs, assign: :windowing_fields, fields: ["inserted_at", "updated_at"])
-  plug(CaptureArgs, assign: :pagination_fields, fields: ["page", "page_size"])
-  plug(CaptureColumnArgs, assign: :column_fields)
+  defp parse_time_range(value) do
+    try do
+      json = Poison.decode!(value)
 
-  def get(conn, _), do: PlenarioWeb.Api.DetailController.get(%{conn | params: Map.merge(conn.params, @params)}, @params)
-  def head(conn, _), do: PlenarioWeb.Api.DetailController.head(%{conn | params: Map.merge(conn.params, @params)}, @params)
-  def describe(conn, _), do: PlenarioWeb.Api.DetailController.describe(%{conn | params: Map.merge(conn.params, @params)}, @params)
+      lower = parse_datetime(json["lower"]) |> Timex.to_erl()
+      {ymd, {h, m, s}} = lower
+      lower = {ymd, {h, m, s, 0}}
+
+      upper = parse_datetime(json["upper"]) |> Timex.to_erl()
+      {ymd, {h, m, s}} = upper
+      upper = {ymd, {h, m, s, 0}}
+
+      %Postgrex.Range{lower: lower, upper: upper}
+    rescue
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(value) do
+    try do
+      Timex.parse!(value, "{ISO:Extended:Z}")
+    rescue
+      _ ->
+        try do
+          Timex.parse!(value, "{ISO:Extended}")
+        rescue
+          _ ->
+            try do
+              Timex.parse!(value, "{ISOdate} {ISOtime}")
+            rescue
+              _ -> nil
+            end
+        end
+    end
+  end
+
+  defp handle_conn_params(conn) do
+    # IEx.pry()
+    # handle meta level filters: network_name, bbox
+    metas = from m in AotMeta
+    metas =
+      case Map.get(conn.params, "network_name") do
+        nil -> metas
+        value ->
+          case is_list(value) do
+            true -> from m in metas, where: m.network_name in ^value or m.slug in ^value
+            false -> from m in metas, where: m.network_name == ^value or m.slug == ^value
+          end
+      end
+    metas =
+      case Map.get(conn.params, "bbox") do
+        nil -> metas
+        value ->
+          bbox = parse_bbox(value)
+          from m in metas, where: st_intersects(m.bbox, ^bbox)
+      end
+
+    meta_ids = Repo.all(
+      from m in metas,
+      select: m.id,
+      distinct: m.id
+    )
+    # IEx.pry()
+
+    # handle data level filters: node_id, timestamp
+    data = from d in AotData, where: d.aot_meta_id in ^meta_ids
+    data =
+      case Map.get(conn.params, "node_id") do
+        nil -> data
+        value ->
+          case is_list(value) do
+            true -> from d in data, where: d.node_id in ^value
+            false -> from d in data, where: d.node_id == ^value
+          end
+      end
+    data =
+      case Map.get(conn.params, "timestamp") do
+        nil -> data
+        value ->
+          [op, term] =
+            case Regex.match?(~r/^in|eq|gt|ge|lt|le\:.*$/, value) do
+              true ->  String.split(value, ":", parts: 2)
+              false -> ["eq", value]
+            end
+
+          term = case op do
+            "in" -> parse_time_range(term)
+            _ -> parse_datetime(term)
+          end
+          case term do
+            nil -> data
+            term ->
+              case op do
+                "eq" -> from d in data, where: fragment("? = ?::timestamp", d.timestamp, ^term)
+                "gt" -> from d in data, where: fragment("? > ?::timestamp", d.timestamp, ^term)
+                "ge" -> from d in data, where: fragment("? >= ?::timestamp", d.timestamp, ^term)
+                "lt" -> from d in data, where: fragment("? < ?::timestamp", d.timestamp, ^term)
+                "le" -> from d in data, where: fragment("? <= ?::timestamp", d.timestamp, ^term)
+                "in" -> from d in data, where: fragment("? <@ ?::tsrange", d.timestamp, ^term)
+                _ -> data
+              end
+          end
+      end
+
+    # TODO: handle observations
+    # handle observation level filters: sensor, {observation}
+    obs_data_ids =
+      case Map.get(conn.params, "sensor") do
+        nil ->
+          nil
+
+        value ->
+          data_ids = Repo.all(
+            from d in data,
+            select: d.id,
+            distinct: d.id
+          )
+          case is_list(value) do
+            true ->
+              Repo.all(
+                from o in AotObservation,
+                where: o.aot_data_id in ^data_ids,
+                where: o.sensor in ^value,
+                select: o.aot_data_id,
+                distinct: o.aot_data_id
+              )
+            false ->
+              Repo.all(
+                from o in AotObservation,
+                where: o.aot_data_id in ^data_ids,
+                where: o.sensor == ^value,
+                select: o.aot_data_id,
+                distinct: o.aot_data_id
+              )
+          end
+      end
+
+    # if observation limited query, apply to data query
+    data =
+      case obs_data_ids do
+        nil -> data
+        value -> from d in data, where: d.id in ^value
+      end
+
+    # return meta and data queries
+    [meta_query: metas, data_query: data]
+  end
+
+  def get(conn, _) do
+    [meta_query: _, data_query: query] = handle_conn_params(conn)
+
+    pagination = [
+      page: Map.get(conn.params, "page", 1),
+      page_size: Map.get(conn.params, "page_size", 500)
+    ]
+
+    page = Repo.paginate(query, pagination)
+    render_page(conn, "get.json", conn.params, page.entries, page)
+  end
+
+  def head(conn, _) do
+    [meta_query: _, data_query: query] = handle_conn_params(conn)
+
+    page = Repo.paginate(query, page: 1, page_size: 1)
+    render_page(conn, "get.json", conn.params, page.entries, page)
+  end
+
+  def describe(conn, _) do
+    [meta_query: query, data_query: _] = handle_conn_params(conn)
+
+    pagination = [
+      page: Map.get(conn.params, "page", 1),
+      page_size: Map.get(conn.params, "page_size", 500)
+    ]
+
+    page = Repo.paginate(query, pagination)
+    render_page(conn, "get.json", conn.params, page.entries, page)
+  end
 end

--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -13,8 +13,6 @@ defmodule PlenarioWeb.Api.AotController do
 
   require Logger
 
-  require IEx
-
   defp parse_bbox(value) do
     try do
       Poison.decode!(value) |> Geo.JSON.decode()
@@ -60,7 +58,6 @@ defmodule PlenarioWeb.Api.AotController do
   end
 
   defp handle_conn_params(conn) do
-    # IEx.pry()
     # handle meta level filters: network_name, bbox
     metas = from m in AotMeta
     metas =
@@ -85,7 +82,6 @@ defmodule PlenarioWeb.Api.AotController do
       select: m.id,
       distinct: m.id
     )
-    # IEx.pry()
 
     # handle data level filters: node_id, timestamp
     data = from d in AotData, where: d.aot_meta_id in ^meta_ids

--- a/lib/plenario_web/views/api/aot_view.ex
+++ b/lib/plenario_web/views/api/aot_view.ex
@@ -1,7 +1,20 @@
 defmodule PlenarioWeb.Api.AotView do
   use PlenarioWeb, :api_view
 
-  def render("get.json", params), do: PlenarioWeb.Api.DetailView.render("get.json", params)
-  def render("head.json", params), do: PlenarioWeb.Api.DetailView.render("get.json", params)
-  def render("describe.json", params), do: PlenarioWeb.Api.DetailView.render("get.json", params)
+  alias PlenarioWeb.Api.DetailView
+
+  def render("get.json", params) do
+    response = DetailView.construct_response(params)
+    %{response | data: DetailView.clean(params[:data])}
+  end
+
+  def render("head.json", params) do
+    response = DetailView.construct_response(params)
+    %{response | data: DetailView.clean(params[:data])}
+  end
+
+  def render("describe.json", params) do
+    response = DetailView.construct_response(params)
+    %{response | data: DetailView.clean(params[:data])}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -1,18 +1,222 @@
 defmodule PlenarioWeb.Api.AotControllerTest do
   use PlenarioWeb.Testing.ConnCase
 
-  # test "GET /api/v2/aot", %{conn: conn} do
-  #   conn = get(conn, "/api/v2/aot")
-  #   assert json_response(conn, 200) == %{}
-  # end
+  alias PlenarioAot.AotActions
 
-  # test "GET /api/v2/aot/@head", %{conn: conn} do
-  #   conn = get(conn, "/api/v2/aot/@head")
-  #   assert json_response(conn, 200) == %{}
-  # end
+  @fixture "test/fixtures/aot-chicago.json"
+  @total_records 1_365
 
-  # test "GET /api/v2/aot/@describe", %{conn: conn} do
-  #   conn = get(conn, "/api/v2/aot/@describe")
-  #   assert json_response(conn, 200) == %{}
-  # end
+  setup do
+    {:ok, meta} = AotActions.create_meta("Chicago", "https://example.com/")
+    File.read!(@fixture)
+    |> Poison.decode!()
+    |> Enum.map(fn obj -> AotActions.insert_data(meta, obj) end)
+    AotActions.compute_and_update_meta_bbox(meta)
+    AotActions.compute_and_update_meta_time_range(meta)
+
+    {:ok, [meta: meta]}
+  end
+
+  test "GET /api/v2/aot", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot")
+    %{"meta" => meta, "data" => data} = json_response(conn, 200)
+
+    assert is_map(meta)
+    assert Map.has_key?(meta, "links")
+    links = meta["links"]
+    assert is_map(links)
+    assert Map.has_key?(links, "current")
+    assert Map.has_key?(links, "previous")
+    assert Map.has_key?(links, "next")
+    assert Map.has_key?(meta, "params")
+    params = meta["params"]
+    assert is_map(params)
+    assert Map.has_key?(meta, "counts")
+    counts = meta["counts"]
+    assert Map.has_key?(counts, "data")
+    assert Map.has_key?(counts, "errors")
+    assert Map.has_key?(counts, "total_pages")
+    assert Map.has_key?(counts, "total_records")
+    assert counts["total_records"] == @total_records
+
+    assert is_list(data)
+    assert length(data) == 500
+    first = Enum.at(data, 0)
+    assert is_map(first)
+    assert Map.has_key?(first, "node_id")
+    assert Map.has_key?(first, "human_address")
+    assert Map.has_key?(first, "timestamp")
+    assert Map.has_key?(first, "latitude")
+    assert Map.has_key?(first, "longitude")
+    assert Map.has_key?(first, "observations")
+  end
+
+  test "GET /api/v2/aot/@head", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot/@head")
+    %{"meta" => meta, "data" => data} = json_response(conn, 200)
+
+    assert is_map(meta)
+    assert Map.has_key?(meta, "links")
+    links = meta["links"]
+    assert is_map(links)
+    assert Map.has_key?(links, "current")
+    assert Map.has_key?(links, "previous")
+    assert Map.has_key?(links, "next")
+    assert Map.has_key?(meta, "params")
+    params = meta["params"]
+    assert is_map(params)
+    assert Map.has_key?(meta, "counts")
+    counts = meta["counts"]
+    assert Map.has_key?(counts, "data")
+    assert Map.has_key?(counts, "errors")
+    assert Map.has_key?(counts, "total_pages")
+    assert Map.has_key?(counts, "total_records")
+
+    assert is_list(data)
+    assert length(data) == 1
+    first = Enum.at(data, 0)
+    assert is_map(first)
+    assert Map.has_key?(first, "node_id")
+    assert Map.has_key?(first, "human_address")
+    assert Map.has_key?(first, "timestamp")
+    assert Map.has_key?(first, "latitude")
+    assert Map.has_key?(first, "longitude")
+    assert Map.has_key?(first, "observations")
+  end
+
+  test "GET /api/v2/aot/@describe", %{conn: conn} do
+    conn = get(conn, "/api/v2/aot/@describe")
+    %{"meta" => meta, "data" => data} = json_response(conn, 200)
+
+    assert is_map(meta)
+    assert Map.has_key?(meta, "links")
+    links = meta["links"]
+    assert is_map(links)
+    assert Map.has_key?(links, "current")
+    assert Map.has_key?(links, "previous")
+    assert Map.has_key?(links, "next")
+    assert Map.has_key?(meta, "params")
+    params = meta["params"]
+    assert is_map(params)
+    assert Map.has_key?(meta, "counts")
+    counts = meta["counts"]
+    assert Map.has_key?(counts, "data")
+    assert Map.has_key?(counts, "errors")
+    assert Map.has_key?(counts, "total_pages")
+    assert Map.has_key?(counts, "total_records")
+
+    assert is_list(data)
+    assert length(data) == 1
+    first = Enum.at(data, 0)
+    assert is_map(first)
+    assert Map.has_key?(first, "network_name")
+    assert Map.has_key?(first, "slug")
+    assert Map.has_key?(first, "source_url")
+    assert Map.has_key?(first, "bbox")
+    assert Map.has_key?(first, "time_range")
+  end
+
+  describe "GET with filter" do
+    test "network_name", %{conn: conn} do
+      conn = get(conn, "/api/v2/aot?network_name=chicago")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+
+      conn = get(conn, "/api/v2/aot?network_name=outer-space")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?network_name=outer-space&network_name=chicago")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+    end
+
+    test "bbox", %{conn: conn} do
+      min_lat = 41.95
+      max_lat = 41.97
+      min_lon = -87.65
+      max_lon = -87.67
+      bbox = %Geo.Polygon{
+        srid: 4326,
+        coordinates: [[
+          {min_lat, max_lon},
+          {min_lat, min_lon},
+          {max_lat, min_lon},
+          {max_lat, max_lon},
+          {min_lat, max_lon}
+        ]]
+      } |> Geo.JSON.encode()
+      conn = get(conn, "/api/v2/aot?bbox=#{bbox}")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+    end
+
+    test "timestamp", %{conn: conn} do
+      conn = get(conn, "/api/v2/aot?timestamp=2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?timestamp=eq:2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?timestamp=gt:2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+
+      conn = get(conn, "/api/v2/aot?timestamp=ge:2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+
+      conn = get(conn, "/api/v2/aot?timestamp=lt:2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?timestamp=le:2018-01-01T00:00:00Z")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?timestamp=in:{\"lower\":\"2018-01-01T00:00:00Z\",\"upper\":\"2019-01-01T00:00:00Z\"}")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+    end
+
+    test "node_id", %{conn: conn} do
+      conn = get(conn, "/api/v2/aot?node_id=088")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 70
+
+      conn = get(conn, "/api/v2/aot?node_id=000")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?node_id=000&node_id=088")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 70
+    end
+
+    test "sensor", %{conn: conn} do
+      conn = get(conn, "/api/v2/aot?sensor=BMP180")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+
+      conn = get(conn, "/api/v2/aot?sensor=eyes")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 0
+
+      conn = get(conn, "/api/v2/aot?sensor=eyes&sensor=BMP180")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == @total_records
+    end
+
+    test "network_name and node_id", %{conn: conn} do
+      conn = get(conn, "/api/v2/aot?network_name=chicago&node_id=088")
+      %{"meta" => meta, "data" => _} = json_response(conn, 200)
+      assert meta["counts"]["total_records"] == 70
+    end
+
+    # TODO: write test after implementation
+    # test "observations" do
+    # end
+  end
 end


### PR DESCRIPTION
i redid the whole aot api to match with the new aot data schema.

**what works:**

- pagination
- filter by `network_name`
- filter by `node_id`
- filter by `timestamp`
- filter by `bbox`
- filter by `sensor`

and any combination of those filters. they all work with single values
and as lists.

i also updated the link generating functions so that they work with the aot api routes.

**what needs to be done:**

- filtering by observations, i.e. `?temperatre=gt:20`

this is a pretty complicated workflow and it'll be a pretty big pr when
it comes.

[describe.txt](https://github.com/UrbanCCD-UChicago/plenario2/files/1984614/describe.txt)
[get-1.txt](https://github.com/UrbanCCD-UChicago/plenario2/files/1984615/get-1.txt)
[get-2.txt](https://github.com/UrbanCCD-UChicago/plenario2/files/1984616/get-2.txt)
[head.txt](https://github.com/UrbanCCD-UChicago/plenario2/files/1984617/head.txt)
