### PR TITLE
Added Seed Script

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,0 +1,106 @@
+defmodule Plenario.DevSeed do
+  import Ecto.Query
+
+  alias Plenario.Repo
+
+  alias Plenario.Actions.{
+    UserActions,
+    MetaActions,
+    DataSetFieldActions,
+    UniqueConstraintActions,
+    VirtualPointFieldActions
+  }
+
+  alias Plenario.Schemas.Meta
+
+  @beach_lab_name "Chicago Beach Lab - DNA Tests"
+
+  @beach_lab_url "https://data.cityofchicago.org/api/views/hmqm-anjq/rows.csv?accessType=DOWNLOAD"
+
+  def seed_regular do
+    if Mix.env() != :dev do
+      error = "This should only be run in the dev enviornment! -- you are in #{Mix.env()}"
+      IO.puts(error)
+      raise "This should only be run in the dev enviornment! -- you are in #{Mix.env()}"
+    end
+
+    found = Repo.one(from m in Meta, where: m.name == ^@beach_lab_name)
+    if !is_nil(found) do
+      error = "Beach lab data already seeded!"
+      IO.puts(error)
+      raise error
+    end
+
+    user =
+      case UserActions.get("plenario@uchicago.edu") do
+        uzer ->
+          uzer
+
+        nil ->
+          {:ok, user} = UserActions.create("Plenario Admin", "plenario@uchicago.edu", "password")
+          user
+      end
+
+    {:ok, user} = UserActions.promote_to_admin(user)
+    IO.puts("default user created. email: `plenario@uchicago.edu` ; password: `password`")
+
+    {:ok, meta} = MetaActions.create(@beach_lab_name, user, @beach_lab_url, "csv")
+
+    {:ok, id} = DataSetFieldActions.create(meta, "DNA Test ID", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Reading Mean", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample 1 Reading", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample 2 Reading", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample Timestamp", "timestamptz")
+    {:ok, loc} = DataSetFieldActions.create(meta, "Location", "text")
+    {:ok, _} = VirtualPointFieldActions.create(meta, loc.id)
+    {:ok, _} = UniqueConstraintActions.create(meta, [id.id])
+
+    {:ok, meta} = MetaActions.submit_for_approval(meta)
+    {:ok, meta} = MetaActions.approve(meta)
+    IO.puts("data set `#{meta.name}` is up")
+
+    {_, task} = PlenarioEtl.ingest(meta)
+    Task.await(task, 300_000)
+
+    MetaActions.mark_first_import(meta)
+  end
+
+  alias PlenarioAot.{AotActions, AotMeta}
+
+  @aot_name "Chicago"
+
+  @aot_url "http://www.mcs.anl.gov/research/projects/waggle/downloads/beehive1/plenario.json"
+
+  def seed_aot do
+    if Mix.env() != :dev do
+      error = "This should only be run in the dev enviornment -- you are in #{Mix.env()}!"
+      IO.puts(error)
+      raise error
+    end
+
+    found = Repo.one(from m in AotMeta, where: m.network_name == ^@aot_name)
+    if !is_nil(found) do
+      error = "AoT Chicago data already seeded!"
+      IO.puts(error)
+      raise error
+    end
+
+    {:ok, _} = AotActions.create_meta(@aot_name, @aot_url)
+    IO.puts("AoT #{@aot_name} created -- let it run for 10 minutes to pull in live data")
+  end
+end
+
+
+try do
+  Plenario.DevSeed.seed_regular()
+rescue
+  _ ->
+    :ok
+end
+
+try do
+  Plenario.DevSeed.seed_aot()
+rescue
+  _ ->
+    :ok
+end


### PR DESCRIPTION
- section for a regular data set
- section for aot chicago

Run this as `mix run priv/repo/seeds.exs` to bootstrap an admin user,
data set and an aot data set.