### PR TITLE
Leaflet marker hotfix

### DIFF
--- a/lib/plenario_web/templates/shared/map.html.eex
+++ b/lib/plenario_web/templates/shared/map.html.eex
@@ -81,12 +81,15 @@
   <% end %>
 
   <%= if @points do %>
-  let icon = L.icon({
-    iconUrl: '/images/marker-icon.png',
-    shadowUrl: '/images/marker-shadow.png'
-  });
+  const markerOpts = {
+    radius: 5,
+    color: "#fff",
+    weight: 2,
+    fillColor: "#dc3545",
+    fillOpacity: 1,
+  };
   <%= for {{pt, name, node_id}, idx} <- Enum.with_index(@points) do %>
-  let pt_<%= idx %> = L.marker(<%= pt %>, {icon: icon});
+  let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
   pt_<%= idx %>.bindPopup("<strong>Node <%= node_id %><br>Located at <%= name %></strong><br><%= pt %>");
   pt_<%= idx %>.addTo(map);
   <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.9.1",
+      version: "0.9.2",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
The leaflet markers are broken. This fixes that, without fixing the underlying Webpack problem that caused the issue (working on it).