### PR TITLE
Use `DateTime.compare/2` instead of `>` operator

### DIFF
--- a/lib/plenario_web/controllers/web/page_controller.ex
+++ b/lib/plenario_web/controllers/web/page_controller.ex
@@ -19,8 +19,15 @@ defmodule PlenarioWeb.Web.PageController do
 
     {startdt, conn} = parse_date(conn, starts)
     {enddt, conn} = parse_date(conn, ends)
+    comparison = DateTime.compare(startdt, enddt)
 
-    do_explorer(zoom, coords, startdt, enddt, conn)
+    case DateTime.compare(startdt, enddt) do
+      :gt ->
+        do_explorer(zoom, coords, startdt, enddt, put_flash(conn, :error,
+          "The starting datetime #{startdt} cannot be greater than the ending datetime #{enddt}"))
+      _ ->
+        do_explorer(zoom, coords, startdt, enddt, conn)
+    end
   end
 
   defp parse_date(conn, nil) do
@@ -43,11 +50,6 @@ defmodule PlenarioWeb.Web.PageController do
 
   defp do_explorer(_, _, _, _, conn = %Plug.Conn{private: %{:phoenix_flash => %{"error" => _}}}) do
     render_explorer(conn, nil, "[41.9, -87.7]", 10, nil, "", "")
-  end
-
-  defp do_explorer(zoom, coords, startdt, enddt, conn) when startdt >= enddt do
-    do_explorer(zoom, coords, startdt, enddt, put_flash(conn, :error,
-      "The starting datetime #{startdt} cannot be greater than the ending datetime #{enddt}"))
   end
 
   defp do_explorer(zoom, coords, startdt, enddt, conn) do

--- a/lib/plenario_web/controllers/web/page_controller.ex
+++ b/lib/plenario_web/controllers/web/page_controller.ex
@@ -19,7 +19,6 @@ defmodule PlenarioWeb.Web.PageController do
 
     {startdt, conn} = parse_date(conn, starts)
     {enddt, conn} = parse_date(conn, ends)
-    comparison = DateTime.compare(startdt, enddt)
 
     case DateTime.compare(startdt, enddt) do
       :gt ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.9.2",
+      version: "0.9.3",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/web/page_controller_test.exs
+++ b/test/plenario_web/controllers/web/page_controller_test.exs
@@ -170,6 +170,9 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
   test "explorer receives start datetime greater than end datetime", %{conn: conn} do
     conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "3000-01-01", "ending_on" => "2000-01-01"})
     assert get_flash(conn)["error"] =~ "cannot be greater than"
+
+    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "2018-03-31", "ending_on" => "2018-05-01"})
+    assert get_flash(conn)["error"] =~ "cannot be greater than"
   end
 
   @tag :anon

--- a/test/plenario_web/controllers/web/page_controller_test.exs
+++ b/test/plenario_web/controllers/web/page_controller_test.exs
@@ -167,11 +167,28 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
   end
 
   @tag :anon
-  test "explorer receives start datetime greater than end datetime", %{conn: conn} do
-    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "3000-01-01", "ending_on" => "2000-01-01"})
-    assert get_flash(conn)["error"] =~ "cannot be greater than"
+  test "explorer receives start datetime and end datetime", %{conn: conn} do
+    params = %{
+      "starting_on" => "2018-03-31",
+      "ending_on" => "2018-05-01",
+      "zoom" => 10,
+      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]"
+    }
 
-    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "2018-03-31", "ending_on" => "2018-05-01"})
+    conn = get(conn, page_path(conn, :explorer), params)
+    assert get_flash(conn)["error"] == nil
+  end
+
+  @tag :anon
+  test "explorer receives start datetime greater than end datetime", %{conn: conn} do
+    params = %{
+      "starting_on" => "2018-05-01",
+      "ending_on" => "2018-04-28",
+      "zoom" => 10,
+      "coords" => "[[30, 20], [40, 50], [10, 30], [30, 20]]"
+    }
+
+    conn = get(conn, page_path(conn, :explorer), params)
     assert get_flash(conn)["error"] =~ "cannot be greater than"
   end
 
@@ -180,4 +197,10 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
     conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "woopwoop", "ending_on" => "2000-01-01"})
     assert get_flash(conn)["error"] =~ "Invalid date woopwoop"
   end
+
+   @tag :anon
+  test "explorer receives a terribly a fake date", %{conn: conn} do
+    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "woopwoop", "ending_on" => "2000-19-11"})
+    assert get_flash(conn)["error"] =~ "date doesn't exist"
+  end 
 end

--- a/test/plenario_web/controllers/web/page_controller_test.exs
+++ b/test/plenario_web/controllers/web/page_controller_test.exs
@@ -199,8 +199,8 @@ defmodule PlenarioWeb.Web.Testing.PageControllerTest do
   end
 
    @tag :anon
-  test "explorer receives a terribly a fake date", %{conn: conn} do
-    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "woopwoop", "ending_on" => "2000-19-11"})
+  test "explorer receives a terribly fake date", %{conn: conn} do
+    conn = get(conn, page_path(conn, :explorer), %{"starting_on" => "2000-01-01", "ending_on" => "2000-19-11"})
     assert get_flash(conn)["error"] =~ "date doesn't exist"
   end 
 end


### PR DESCRIPTION
>Remember, comparisons in Elixir using ==, >, < and friends are structural and based on the DateTime struct fields. For proper comparison between datetimes, use the compare/2 function.

Herpaderp.

- Close #310 
- Bump to version `0.9.3`