### PR TITLE
Bbox keyword for metas

### DIFF
--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -156,6 +156,14 @@ defmodule PlenarioWeb.Api.Utils do
   end
 
   @doc """
+  Generates an intersection query for a given geom. This condition is pretty much only
+  used for the `bbox` filter when applied to metadata records.
+  """
+  def where_condition(query, {column, {"intersects", %Geo.Polygon{} = polygon}}) do
+    from(q in query, where: st_intersects(field(q, ^column), ^polygon))
+  end
+
+  @doc """
   Shortcut for {column}=eq:{value}. User can provide the conditions as just {column}={value}.
   """
   def where_condition(query, {column, value}) do

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -3,7 +3,7 @@ defmodule PlenarioWeb.Router do
 
   use Plug.ErrorHandler
 
-  use Sentry.Plug
+  # use Sentry.Plug
 
   pipeline :browser do
     plug :accepts, ["html"]

--- a/lib/plenario_web/router.ex
+++ b/lib/plenario_web/router.ex
@@ -3,7 +3,7 @@ defmodule PlenarioWeb.Router do
 
   use Plug.ErrorHandler
 
-  # use Sentry.Plug
+  use Sentry.Plug
 
   pipeline :browser do
     plug :accepts, ["html"]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.9.3",
+      version: "0.9.4",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Because `bbox` was an actual column of `Meta` objects, I thought the query builder would handle things if I wrote something like `data-sets/bbox=in:{geom}`. Couldn't get things to query successfully, so I threw in some code to take `data-sets/bbox={geom}` and turn it into an `ST_Intersects` query.

- Added tests
- Bump to version `0.9.4`