### PR TITLE
Revamped ETL System

### DIFF
--- a/lib/plenario/field_guesser.ex
+++ b/lib/plenario/field_guesser.ex
@@ -104,12 +104,6 @@ defmodule Plenario.FieldGuesser do
     |> Enum.take(count)
   end
 
-  defp parse!(filename, count, %Meta{source_type: "json"}) do
-    File.read!(filename)
-    |> Poison.decode!()
-    |> Enum.take(count)
-  end
-
   defp parse!(_, _, %Meta{source_type: "shp"}) do
     []
   end

--- a/lib/plenario/schemas/meta.ex
+++ b/lib/plenario/schemas/meta.ex
@@ -55,12 +55,11 @@ defmodule Plenario.Schemas.Meta do
     Years: "years"
   ]
 
-  @source_type_values ["csv", "tsv", "json", "shp"]
+  @source_type_values ["csv", "tsv", "shp"]
 
   @source_type_choices [
     CSV: "csv",
     TSV: "tsv",
-    JSON: "json",
     Shapefile: "shp"
   ]
 

--- a/test/plenario/actions/meta_actions_test.exs
+++ b/test/plenario/actions/meta_actions_test.exs
@@ -100,7 +100,7 @@ defmodule Plenario.Actions.MetaActionsTest do
     end
 
     test "source type", %{meta: meta} do
-      new_type = "json"
+      new_type = "tsv"
       {:ok, _} = MetaActions.update(meta, source_type: new_type)
 
       meta = MetaActions.get(meta.id)

--- a/test/plenario/field_guesser_test.exs
+++ b/test/plenario/field_guesser_test.exs
@@ -98,18 +98,6 @@ defmodule Plenario.FieldGuesserTest do
     end
   end
 
-  test "guess_field_types!/1 of json", %{meta: meta} do
-    {:ok, meta} = Plenario.Actions.MetaActions.update(meta, source_type: "json")
-    with_mock HTTPoison, get!: &mock_json_data_request/1 do
-      assert guess_field_types!(meta) == %{
-        "pk" => "integer",
-        "datetime" => "timestamptz",
-        "location" => "text",
-        "data" => "text"
-      }
-    end
-  end
-
   test "guess/1" do
     assert guess("true") == "boolean"
     assert guess("7") == "integer"

--- a/test/plenario_etl/worker_test.exs
+++ b/test/plenario_etl/worker_test.exs
@@ -15,15 +15,7 @@ defmodule PlenarioEtl.Testing.WorkerTest do
 
   alias PlenarioEtl.Actions.EtlJobActions
 
-  @json_fixture_path "test/fixtures/aot-chicago.json"
-
-  @corrupt_json_fixture_path "test/fixtures/aot-chicago-corrupted.json"
-
-  @fail_json_fixture_path "test/fixtures/aot-chicago-fail.json"
-
   @csv_fixutre_path "test/fixtures/beach-lab-dna.csv"
-
-  @corrupt_csv_fixutre_path "test/fixtures/beach-lab-dna-corrupted.csv"
 
   @fail_csv_fixutre_path "test/fixtures/beach-lab-dna-fail.csv"
 
@@ -41,37 +33,38 @@ defmodule PlenarioEtl.Testing.WorkerTest do
     {:ok, user} = UserActions.create("name", "email@example.com", "password")
 
     # setup a metas with fields, etc.
-    {:ok, csv_meta} = MetaActions.create("Chicago Beach Lab DNA Tests", user, "https://example.com/csv", "csv")
-    {:ok, _} = DataSetFieldActions.create(csv_meta, "DNA Test ID", "text")
-    {:ok, _} = DataSetFieldActions.create(csv_meta, "DNA Reading Mean", "float")
-    {:ok, _} = DataSetFieldActions.create(csv_meta, "DNA Sample 1 Reading", "float")
-    {:ok, _} = DataSetFieldActions.create(csv_meta, "DNA Sample 2 Reading", "float")
-    {:ok, _} = DataSetFieldActions.create(csv_meta, "DNA Sample Timestamp", "timestamptz")
-    {:ok, loc} = DataSetFieldActions.create(csv_meta, "Location", "text")
-    {:ok, _} = VirtualPointFieldActions.create(csv_meta, loc.id)
-
-    {:ok, json_meta} = MetaActions.create("Array of Things Chicago", user, "https://example.com/json", "json")
-    {:ok, _} = DataSetFieldActions.create(json_meta, "node_id", "text")
-    {:ok, lat} = DataSetFieldActions.create(json_meta, "latitude", "float")
-    {:ok, lon} = DataSetFieldActions.create(json_meta, "longitude", "float")
-    {:ok, _} = DataSetFieldActions.create(json_meta, "timestamp", "timestamptz")
-    {:ok, _} = DataSetFieldActions.create(json_meta, "observations", "jsonb")
-    {:ok, _} = DataSetFieldActions.create(json_meta, "human_address", "text")
-    {:ok, _} = VirtualPointFieldActions.create(json_meta, lat.id, lon.id)
+    {:ok, meta} = MetaActions.create("Chicago Beach Lab DNA Tests", user, "https://example.com/csv", "csv")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Test ID", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample Timestamp", "timestamptz")
+    {:ok, _} = DataSetFieldActions.create(meta, "Beach", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample 1 Reading", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Sample 2 Reading", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "DNA Reading Mean", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Test ID", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Sample 1 Timestamp", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Sample 1 Reading", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Sample 2 Reading", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Reading Mean", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Note", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Sample Interval", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "Culture Sample 2 Timestamp", "text")
+    {:ok, lat} = DataSetFieldActions.create(meta, "Latitude", "float")
+    {:ok, lon} = DataSetFieldActions.create(meta, "Longitude", "float")
+    {:ok, _} = DataSetFieldActions.create(meta, "Location", "text")
+    {:ok, _} = VirtualPointFieldActions.create(meta, lat.id, lon.id)
 
     # bring up the data set tables
-    :ok = DataSetActions.up!(csv_meta)
-    :ok = DataSetActions.up!(json_meta)
+    :ok = DataSetActions.up!(meta)
 
     # return context
-    {:ok, [csv_meta: csv_meta, json_meta: json_meta, user: user]}
+    {:ok, [meta: meta, user: user]}
   end
 
   defp mock_options_response(_), do: %HTTPoison.Response{status_code: 200}
 
   defp mock_get_response(path), do: %HTTPoison.Response{body: File.read!(path)}
 
-  test "ingest csv", %{csv_meta: meta} do
+  test "ingest csv", %{meta: meta} do
     with_mock HTTPoison, options!: &mock_options_response/1 do
       # set meta's source url so we get the right fixture
       {:ok, _} = MetaActions.update(meta, source_url: @csv_fixutre_path)
@@ -91,90 +84,10 @@ defmodule PlenarioEtl.Testing.WorkerTest do
     end
   end
 
-  test "ingest json", %{json_meta: meta} do
-    with_mock HTTPoison, options!: &mock_options_response/1 do
-      # set meta's source url so we get the right fixture
-      {:ok, _} = MetaActions.update(meta, source_url: @json_fixture_path)
-    end
-
-    with_mock HTTPoison, get!: &mock_get_response/1 do
-      # ingest the data set
-      {job, task} = PlenarioEtl.ingest(meta)
-
-      # wait for the job to finish
-      Task.await(task, 300_000)
-
-      # get the refreshed job from the database and ensure its success
-      job = EtlJobActions.get(job.id)
-      assert job.state == "succeeded"
-      refute job.error_message
-    end
-  end
-
-  test "ingest csv partial success", %{csv_meta: meta} do
-    with_mock HTTPoison, options!: &mock_options_response/1 do
-      # set meta's source url so we get the right fixture
-      {:ok, _} = MetaActions.update(meta, source_url: @corrupt_csv_fixutre_path)
-    end
-
-    with_mock HTTPoison, get!: &mock_get_response/1 do
-      # ingest the data set
-      {job, task} = PlenarioEtl.ingest(meta)
-
-      # wait for the job to finish
-      Task.await(task, 300_000)
-
-      # get the refreshed job from the database and ensure its success
-      job = EtlJobActions.get(job.id)
-      assert job.state == "partial_success"
-      assert job.error_message
-    end
-  end
-
-  test "ingest json partial success", %{json_meta: meta} do
-    with_mock HTTPoison, options!: &mock_options_response/1 do
-      # set meta's source url so we get the right fixture
-      {:ok, _} = MetaActions.update(meta, source_url: @corrupt_json_fixture_path)
-    end
-
-    with_mock HTTPoison, get!: &mock_get_response/1 do
-      # ingest the data set
-      {job, task} = PlenarioEtl.ingest(meta)
-
-      # wait for the job to finish
-      Task.await(task, 300_000)
-
-      # get the refreshed job from the database and ensure its success
-      job = EtlJobActions.get(job.id)
-      assert job.state == "partial_success"
-      assert job.error_message
-    end
-  end
-
-  test "ingest csv fail", %{csv_meta: meta} do
+  test "ingest csv fail", %{meta: meta} do
     with_mock HTTPoison, options!: &mock_options_response/1 do
       # set meta's source url so we get the right fixture
       {:ok, _} = MetaActions.update(meta, source_url: @fail_csv_fixutre_path)
-    end
-
-    with_mock HTTPoison, get!: &mock_get_response/1 do
-      # ingest the data set
-      {job, task} = PlenarioEtl.ingest(meta)
-
-      # wait for the job to finish
-      Task.await(task, 300_000)
-
-      # get the refreshed job from the database and ensure its success
-      job = EtlJobActions.get(job.id)
-      assert job.state == "erred"
-      assert job.error_message
-    end
-  end
-
-  test "ingest json fail", %{json_meta: meta} do
-    with_mock HTTPoison, options!: &mock_options_response/1 do
-      # set meta's source url so we get the right fixture
-      {:ok, _} = MetaActions.update(meta, source_url: @fail_json_fixture_path)
     end
 
     with_mock HTTPoison, get!: &mock_get_response/1 do


### PR DESCRIPTION
i was able to rip out a significant chunk of the ETL pipeline and just
use the native postgres loading stuff i added into datasetactions.

i also removed `json` as an acceptible source type for metas. there's a
couple reasons for this:

1. it cleans up the etl process
2. we don't have an immediate use case for it here
3. at some point we may need to support it, but that would most likely
   be from a data set that progressively releases data rather than the
   stuff we have now (basically an _all things for all time_ payload)
   and at which point we would need a totally different type of etl

next up: fixing scheduling bugs and cleaning up a lot of the
create/update/admin workflow around metas