### PR TITLE
Pagination limit

### DIFF
--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -2,16 +2,16 @@ defmodule PlenarioWeb.Api.AotController do
   use PlenarioWeb, :api_controller
 
   import Ecto.Query
-
   import Geo.PostGIS, only: [st_intersects: 2]
-
   import PlenarioWeb.Api.Utils, only: [render_page: 6]
 
   alias Plenario.Repo
-
   alias PlenarioAot.{AotData, AotMeta, AotObservation}
+  alias Plug.Conn
 
   require Logger
+
+  plug :with_page_size, default_page_size: 500, page_size_limit: 5000
 
   defp parse_bbox(value) do
     try do
@@ -206,5 +206,54 @@ defmodule PlenarioWeb.Api.AotController do
 
     page = Repo.paginate(query, pagination)
     render_page(conn, "get.json", conn.params, page.entries, page, true)
+  end
+
+  @doc """
+  This function guarantees two outcomes. The returned `conn` will have a valid `page_size` in `params`, even if no
+  `page_size` was provided. If a `page_size` was provided that is invalid (not a number, smaller than 0 or larger than
+  the `:page_size_limit` opt), it breaks the pipeline early and returns a conn with an error.
+
+  This is an implementation of the `call/2` method for building a plug. It's meant to be used in combination
+  with the plug macro to be *plugged* (heh) into a request handling pipeline.
+
+  ## Examples
+
+      iex> use Plug.Builder
+      iex> plug :with_page_size, default_page_size: 500, page_size_limit: 5000
+
+  """
+  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) when is_integer(page_size) do
+    case (opts[:page_size_limit] > page_size) and (page_size > 0) do
+      true ->
+        conn
+      false ->
+        conn
+        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
+        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid value
+        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+    end
+  end
+
+  @doc """
+  "page_size" not an integer? Attempt to parse it to an integer and toss it back up. If parsing fails, halt the
+  request pipeline and inform the user.
+  """
+  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) do
+    case Integer.parse(page_size) do
+      {parsed_page_size, _} ->
+        with_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
+      :error ->
+        conn
+        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
+        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid integer
+        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+    end
+  end
+
+  @doc """
+  No "page_size" specified? Assign the default and toss it back up.
+  """
+  def with_page_size(conn, opts) do
+    with_page_size(%{conn | params: Map.put(conn.params, "page_size", opts[:default_page_size])}, opts)
   end
 end

--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -3,11 +3,11 @@ defmodule PlenarioWeb.Api.AotController do
 
   import Ecto.Query
   import Geo.PostGIS, only: [st_intersects: 2]
+  import PlenarioWeb.Api.Plugs, only: [with_page_size: 2]
   import PlenarioWeb.Api.Utils, only: [render_page: 6]
 
   alias Plenario.Repo
   alias PlenarioAot.{AotData, AotMeta, AotObservation}
-  alias Plug.Conn
 
   require Logger
 
@@ -206,54 +206,5 @@ defmodule PlenarioWeb.Api.AotController do
 
     page = Repo.paginate(query, pagination)
     render_page(conn, "get.json", conn.params, page.entries, page, true)
-  end
-
-  @doc """
-  This function guarantees two outcomes. The returned `conn` will have a valid `page_size` in `params`, even if no
-  `page_size` was provided. If a `page_size` was provided that is invalid (not a number, smaller than 0 or larger than
-  the `:page_size_limit` opt), it breaks the pipeline early and returns a conn with an error.
-
-  This is an implementation of the `call/2` method for building a plug. It's meant to be used in combination
-  with the plug macro to be *plugged* (heh) into a request handling pipeline.
-
-  ## Examples
-
-      iex> use Plug.Builder
-      iex> plug :with_page_size, default_page_size: 500, page_size_limit: 5000
-
-  """
-  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) when is_integer(page_size) do
-    case (opts[:page_size_limit] > page_size) and (page_size > 0) do
-      true ->
-        conn
-      false ->
-        conn
-        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
-        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid value
-        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
-    end
-  end
-
-  @doc """
-  "page_size" not an integer? Attempt to parse it to an integer and toss it back up. If parsing fails, halt the
-  request pipeline and inform the user.
-  """
-  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) do
-    case Integer.parse(page_size) do
-      {parsed_page_size, _} ->
-        with_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
-      :error ->
-        conn
-        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
-        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid integer
-        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
-    end
-  end
-
-  @doc """
-  No "page_size" specified? Assign the default and toss it back up.
-  """
-  def with_page_size(conn, opts) do
-    with_page_size(%{conn | params: Map.put(conn.params, "page_size", opts[:default_page_size])}, opts)
   end
 end

--- a/lib/plenario_web/controllers/api/list_controller.ex
+++ b/lib/plenario_web/controllers/api/list_controller.ex
@@ -1,6 +1,7 @@
 defmodule PlenarioWeb.Api.ListController do
   use PlenarioWeb, :api_controller
   import Ecto.Query
+  import PlenarioWeb.Api.Plugs, only: [with_page_size: 2]
   import PlenarioWeb.Api.Utils, only: [render_page: 5, map_to_query: 2]
   alias Plenario.Repo
   alias Plenario.Schemas.Meta
@@ -41,7 +42,8 @@ defmodule PlenarioWeb.Api.ListController do
 
   plug(CaptureArgs, assign: :ordering_fields, fields: ["order_by"])
   plug(CaptureArgs, assign: :windowing_fields, fields: ["inserted_at", "updated_at"])
-  plug(CaptureArgs, assign: :pagination_fields, fields: ["page", "page_size"])
+  plug :with_page_size, default_page_size: 500, page_size_limit: 5000
+  plug(CaptureArgs, assign: :pagination_fields, fields: ["page"])
   plug(CaptureColumnArgs, assign: :column_fields)
   plug(CaptureBboxArg, assign: :bbox_fields)
 
@@ -68,14 +70,15 @@ defmodule PlenarioWeb.Api.ListController do
   @doc """
   Lists all metadata objects satisfying the provided query.
   """
-  def get(conn, _params) do
+  def get(conn, %{"page_size": page_size}) do
     pagination_fields = Map.get(conn.assigns, :pagination_fields)
     {query, params_used} = construct_query_from_conn_assigns(conn)
-    page = Repo.paginate(query, pagination_fields)
+    # todo(heyzoos) pass in page through params
+    page = Repo.paginate(query, page_size: page_size, page: pagination_fields[:page])
     render_page(conn, "get.json", params_used ++ pagination_fields, page.entries, page)
   end
 
-  def head(conn, _params) do
+  def head(conn, %{"page_size": page_size}) do
     pagination_fields = Map.get(conn.assigns, :pagination_fields)
     {query, params_used} = construct_query_from_conn_assigns(conn)
     page = Repo.paginate(query, page_size: 1, page: 1)
@@ -86,10 +89,10 @@ defmodule PlenarioWeb.Api.ListController do
   Lists all single metadata objects satisfying the provided query. The metadata
   objects have all associations preloaded.
   """
-  def describe(conn, _params) do
+  def describe(conn, %{"page_size": page_size}) do
     pagination_fields = Map.get(conn.assigns, :pagination_fields)
     {query, params_used} = construct_query_from_conn_assigns(conn)
-    page = Repo.paginate(preload(query, ^@associations), pagination_fields)
+    page = Repo.paginate(query, page_size: page_size, page: pagination_fields[:page])
     render_page(conn, "get.json", params_used ++ pagination_fields, page.entries, page)
   end
 end

--- a/lib/plenario_web/controllers/api/list_controller.ex
+++ b/lib/plenario_web/controllers/api/list_controller.ex
@@ -70,16 +70,16 @@ defmodule PlenarioWeb.Api.ListController do
   @doc """
   Lists all metadata objects satisfying the provided query.
   """
-  def get(conn, %{"page_size": page_size}) do
-    pagination_fields = Map.get(conn.assigns, :pagination_fields)
+  def get(conn, %{"page_size" => page_size}) do
+    pagination_fields = Map.get(conn.assigns, :pagination_fields) ++ [page_size: page_size]
     {query, params_used} = construct_query_from_conn_assigns(conn)
     # todo(heyzoos) pass in page through params
-    page = Repo.paginate(query, page_size: page_size, page: pagination_fields[:page])
+    page = Repo.paginate(query, pagination_fields)
     render_page(conn, "get.json", params_used ++ pagination_fields, page.entries, page)
   end
 
-  def head(conn, %{"page_size": page_size}) do
-    pagination_fields = Map.get(conn.assigns, :pagination_fields)
+  def head(conn, %{"page_size" => _}) do
+    pagination_fields = Map.get(conn.assigns, :pagination_fields) ++ [page_size: 1]
     {query, params_used} = construct_query_from_conn_assigns(conn)
     page = Repo.paginate(query, page_size: 1, page: 1)
     render_page(conn, "get.json", params_used ++ pagination_fields, page.entries, page)
@@ -89,10 +89,10 @@ defmodule PlenarioWeb.Api.ListController do
   Lists all single metadata objects satisfying the provided query. The metadata
   objects have all associations preloaded.
   """
-  def describe(conn, %{"page_size": page_size}) do
-    pagination_fields = Map.get(conn.assigns, :pagination_fields)
+  def describe(conn, %{"page_size" => page_size}) do
+    pagination_fields = Map.get(conn.assigns, :pagination_fields) ++ [page_size: page_size]
     {query, params_used} = construct_query_from_conn_assigns(conn)
-    page = Repo.paginate(query, page_size: page_size, page: pagination_fields[:page])
+    page = Repo.paginate(preload(query, ^@associations), pagination_fields)
     render_page(conn, "get.json", params_used ++ pagination_fields, page.entries, page)
   end
 end

--- a/lib/plenario_web/controllers/api/plugs.ex
+++ b/lib/plenario_web/controllers/api/plugs.ex
@@ -1,0 +1,65 @@
+defmodule PlenarioWeb.Api.Plugs do
+  use PlenarioWeb, :api_controller
+  alias Plug.Conn
+
+  @doc """
+  This function guarantees two outcomes. The returned `conn` will have a valid `page_size` in `params`, even if no
+  `page_size` was provided. If a `page_size` was provided that is invalid (not a number, smaller than 0 or larger than
+  the `:page_size_limit` opt), it breaks the pipeline early and returns a conn with an error.
+
+  This is an implementation of the `call/2` method for building a plug. It's meant to be used in combination
+  with the plug macro to be *plugged* (heh) into a request handling pipeline.
+
+  ## Examples
+
+      iex> use Plug.Builder
+      iex> plug :with_page_size, default_page_size: 500, page_size_limit: 5000
+
+      iex> conn = %Conn{params: %{}}
+      iex> with_page_size(conn, default_page_size: 500, page_size_limit: 5000)
+      %Conn{params: %{"page_size" => 500}}
+
+      iex> conn = %Conn{params: %{"page_size" => "wrong"}}
+      iex> with_page_size(conn, default_page_size: 500, page_size_limit: 5000)
+      %Conn{status: 422}
+
+      iex> conn = %Conn{params: %{"page_size" => "5001"}}
+      iex> with_page_size(conn, default_page_size: 500, page_size_limit: 5000)
+      %Conn{status: 422}
+
+  """
+  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) when is_integer(page_size) do
+    case (opts[:page_size_limit] > page_size) and (page_size > 0) do
+      true ->
+        conn
+      false ->
+        conn
+        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
+        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid value
+        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+    end
+  end
+
+  @doc """
+  "page_size" not an integer? Attempt to parse it to an integer and toss it back up. If parsing fails, halt the
+  request pipeline and inform the user.
+  """
+  def with_page_size(conn = %Conn{params: %{"page_size" => page_size}}, opts) do
+    case Integer.parse(page_size) do
+      {parsed_page_size, _} ->
+        with_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
+      :error ->
+        conn
+        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
+        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid integer
+        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+    end
+  end
+
+  @doc """
+  No "page_size" specified? Assign the default and toss it back up.
+  """
+  def with_page_size(conn, opts) do
+    with_page_size(%{conn | params: Map.put(conn.params, "page_size", opts[:default_page_size])}, opts)
+  end
+end

--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -196,6 +196,11 @@ defmodule PlenarioWeb.Api.Utils do
 
   @doc """
   Truncates a database table, lives here for now until I can find a better place for it.
+
+  todo(heyzoos) add an informative error if you receive something that isn't a struct
+    - usually caused by passing an atom without aliasing it
+    - or caused by not being an ecto schema
+
   """
   def truncate([]), do: :ok
   def truncate([schema | tail]) do
@@ -205,6 +210,6 @@ defmodule PlenarioWeb.Api.Utils do
 
   def truncate(schema) do
     {nil, table} = schema.__struct__.__meta__.source
-    Ecto.Adapters.SQL.query!(Repo, "truncate #{table} cascade;", [])
+    Ecto.Adapters.SQL.query!(Repo, "truncate \"#{table}\" cascade;", [])
   end
 end

--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -2,6 +2,7 @@ defmodule PlenarioWeb.Api.Utils do
   import Ecto.Query
   import PlenarioWeb.Router.Helpers, only: [detail_url: 4, list_url: 3, aot_url: 3]
   import Geo.PostGIS
+  alias Plenario.Repo
 
   @doc """
   Utility function for rendering a `Scrivener.Page` of results. Even if the
@@ -191,5 +192,19 @@ defmodule PlenarioWeb.Api.Utils do
   def map_to_query(query, params) when is_map(params), do: map_to_query(query, Map.to_list(params))
   def map_to_query(query, [condition_tuple | params]) do
     map_to_query(query |> where_condition(condition_tuple), params)
+  end
+
+  @doc """
+  Truncates a database table, lives here for now until I can find a better place for it.
+  """
+  def truncate([]), do: :ok
+  def truncate([schema | tail]) do
+    truncate(schema)
+    truncate(tail)
+  end
+
+  def truncate(schema) do
+    {nil, table} = schema.__struct__.__meta__.source
+    Ecto.Adapters.SQL.query!(Repo, "truncate #{table} cascade;", [])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.9.5",
+      version: "0.9.6",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -219,4 +219,31 @@ defmodule PlenarioWeb.Api.AotControllerTest do
     # test "observations" do
     # end
   end
+
+  test "page_size param cannot exceed 5000" do
+    %{"meta" => meta, "errors" => errors} =
+      get(build_conn(), "/api/v2/aot?page_size=5001")
+      |> json_response(422)
+
+    assert meta["counts"]["total_records"] == 0
+    assert errors == [[page_size: "Argument cannot exceed 5000."]]
+  end
+
+  test "page_size param cannot be less than 1" do
+    %{"meta" => meta, "errors" => errors} =
+      get(build_conn(), "/api/v2/aot?page_size=0")
+      |> json_response(422)
+
+    assert meta["counts"]["total_records"] == 0
+    assert errors == [[page_size: "Argument cannot be less than 1."]]
+  end
+
+  test "page_size param cannot be negative" do
+    %{"meta" => meta, "errors" => errors} =
+      get(build_conn(), "/api/v2/aot?page_size=-1")
+      |> json_response(422)
+
+    assert meta["counts"]["total_records"] == 0
+    assert errors == [[page_size: "Argument cannot be less than 1."]]
+  end
 end

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -221,29 +221,39 @@ defmodule PlenarioWeb.Api.AotControllerTest do
   end
 
   test "page_size param cannot exceed 5000" do
-    %{"meta" => meta, "errors" => errors} =
+    error =
       get(build_conn(), "/api/v2/aot?page_size=5001")
       |> json_response(422)
 
-    assert meta["counts"]["total_records"] == 0
-    assert errors == [[page_size: "Argument cannot exceed 5000."]]
+    assert error == "__ERROR__"
   end
 
   test "page_size param cannot be less than 1" do
-    %{"meta" => meta, "errors" => errors} =
+    error =
       get(build_conn(), "/api/v2/aot?page_size=0")
       |> json_response(422)
 
-    assert meta["counts"]["total_records"] == 0
-    assert errors == [[page_size: "Argument cannot be less than 1."]]
+    assert error == "__ERROR__"
   end
 
   test "page_size param cannot be negative" do
-    %{"meta" => meta, "errors" => errors} =
+    error =
       get(build_conn(), "/api/v2/aot?page_size=-1")
       |> json_response(422)
 
-    assert meta["counts"]["total_records"] == 0
-    assert errors == [[page_size: "Argument cannot be less than 1."]]
+    assert error == "__ERROR__"
+  end
+
+  test "page_size cannot be a string" do
+    error =
+      get(build_conn(), "/api/v2/aot?page_size=string")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "valid page_size param" do
+    get(build_conn(), "/api/v2/aot?page_size=501")
+    |> json_response(200)
   end
 end

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -11,9 +11,14 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
     VirtualPointFieldActions
   }
 
-  setup do
-    Ecto.Adapters.SQL.Sandbox.checkout(Plenario.Repo)
-    Ecto.Adapters.SQL.Sandbox.mode(Plenario.Repo, {:shared, self()})
+  alias Plenario.Schemas.{DataSetField, Meta, UniqueConstraint, User, VirtualPointField}
+
+  # Setting up the fixure data once _greatly_ reduces the test time. Drops this particular test
+  # case from _ to _ as of writing. The downside is that in order to make this work you must
+  # be explicit about database connection ownership and you must also clean up the tests yourself.
+  setup_all do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, :auto)
 
     {:ok, user} = UserActions.create("API Test User", "test@example.com", "password")
     {:ok, meta} = MetaActions.create("API Test Dataset", user.id, "https://www.example.com", "csv")
@@ -31,6 +36,15 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
     model = ModelRegistry.lookup(meta.slug())
     (1..100) |> Enum.each(fn _ ->
       Repo.insert(%{model.__struct__ | datetime: "2500-01-01 00:00:00", location: "(50, 50)"})
+    end)
+
+    # Registers a callback that runs once (because we're in setup_all) after all the tests have run. Use to clean up!
+    # If things screw up and this isn't called properly, `env MIX_ENV=test mix ecto.drop` (bash) is your friend.
+    on_exit(fn ->
+      # Check out again because this callback is run in another process.
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      Ecto.Adapters.SQL.Sandbox.mode(Repo, :auto)
+      :ok = truncate([DataSetField, Meta, UniqueConstraint, User, VirtualPointField])
     end)
 
     %{slug: meta.slug(), vpf: vpf}
@@ -205,5 +219,42 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
     conn = get(build_conn(), "/api/v2/data-sets/#{slug}?#{vpf.name}=in:#{geojson}")
     response = json_response(conn, 200)
     assert length(response["data"]) == 0
+  end
+
+  test "page_size param cannot exceed 5000", %{slug: slug} do
+    error =
+      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=5001")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size param cannot be less than 1", %{slug: slug} do
+    error =
+      get(build_conn(), "/api/v2/#{slug}?page_size=0")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size param cannot be negative", %{slug: slug} do
+    error =
+      get(build_conn(), "/api/v2/#{slug}?page_size=-1")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size cannot be a string", %{slug: slug} do
+    error =
+      get(build_conn(), "/api/v2/#{slug}?page_size=string")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "valid page_size param", %{slug: slug} do
+    get(build_conn(), "/api/v2/#{slug}?page_size=501")
+    |> json_response(200)
   end
 end

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -13,9 +13,10 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
 
   alias Plenario.Schemas.{DataSetField, Meta, UniqueConstraint, User, VirtualPointField}
 
-  # Setting up the fixure data once _greatly_ reduces the test time. Drops this particular test
-  # case from _ to _ as of writing. The downside is that in order to make this work you must
-  # be explicit about database connection ownership and you must also clean up the tests yourself.
+  import PlenarioWeb.Api.Utils, only: [truncate: 1]
+
+  # Setting up the fixure data once _greatly_ reduces the test time. The downside is that in order to make this work
+  # you must be explicit about database connection ownership and you must also clean up the tests yourself.
   setup_all do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, :auto)
@@ -44,7 +45,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
       # Check out again because this callback is run in another process.
       :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
       Ecto.Adapters.SQL.Sandbox.mode(Repo, :auto)
-      :ok = truncate([DataSetField, Meta, UniqueConstraint, User, VirtualPointField])
+      truncate([DataSetField, Meta, UniqueConstraint, User, VirtualPointField, model])
     end)
 
     %{slug: meta.slug(), vpf: vpf}
@@ -87,7 +88,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
     response = json_response(conn, 200)
     assert length(response["data"]) == 5
     assert response["meta"]["params"]["page"] == "2"
-    assert response["meta"]["params"]["page_size"] == "5"
+    assert response["meta"]["params"]["page_size"] == 5
   end
 
   test "GET /api/v2/data-sets/:slug pagination is stable with backfills", %{slug: slug} do
@@ -96,7 +97,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
 
     assert length(response["data"]) == 5
     assert response["meta"]["params"]["page"] == "2"
-    assert response["meta"]["params"]["page_size"] == "5"
+    assert response["meta"]["params"]["page_size"] == 5
   end
 
   test "GET /api/v2/data-sets/:slug populates pagination links", %{slug: slug} do
@@ -126,7 +127,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   end
 
   test "GET /api/v2/data-sets/:slug bbox query", %{slug: slug} do
-    geojson = 
+    geojson =
       """
       {
         "type": "Polygon",
@@ -147,7 +148,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   end
 
   test "GET /api/v2/data-sets/:slug bbox query no results", %{slug: slug} do
-    geojson = 
+    geojson =
       """
       {
         "type": "Polygon",
@@ -180,7 +181,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   end
 
   test "GET /api/v2/data-sets/:slug location query", %{slug: slug, vpf: vpf} do
-    geojson = 
+    geojson =
       """
       {
         "type": "Polygon",
@@ -201,7 +202,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   end
 
   test "GET /api/v2/data-sets/:slug location query no results", %{slug: slug, vpf: vpf} do
-    geojson = 
+    geojson =
       """
       {
         "type": "Polygon",
@@ -231,7 +232,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
 
   test "page_size param cannot be less than 1", %{slug: slug} do
     error =
-      get(build_conn(), "/api/v2/#{slug}?page_size=0")
+      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=0")
       |> json_response(422)
 
     assert error == "__ERROR__"
@@ -239,7 +240,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
 
   test "page_size param cannot be negative", %{slug: slug} do
     error =
-      get(build_conn(), "/api/v2/#{slug}?page_size=-1")
+      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=-1")
       |> json_response(422)
 
     assert error == "__ERROR__"
@@ -247,14 +248,14 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
 
   test "page_size cannot be a string", %{slug: slug} do
     error =
-      get(build_conn(), "/api/v2/#{slug}?page_size=string")
+      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=string")
       |> json_response(422)
 
     assert error == "__ERROR__"
   end
 
   test "valid page_size param", %{slug: slug} do
-    get(build_conn(), "/api/v2/#{slug}?page_size=501")
+    get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=501")
     |> json_response(200)
   end
 end

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -172,4 +172,41 @@ defmodule PlenarioWeb.Api.ListControllerTest do
     result = json_response(conn, 200)
     assert length(result["data"]) == 2
   end
+
+  test "page_size param cannot exceed 5000" do
+    error =
+      get(build_conn(), "/api/v2/data-sets?page_size=5001")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size param cannot be less than 1" do
+    error =
+      get(build_conn(), "/api/v2/data-sets?page_size=0")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size param cannot be negative" do
+    error =
+      get(build_conn(), "/api/v2/data-sets?page_size=-1")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "page_size cannot be a string" do
+    error =
+      get(build_conn(), "/api/v2/data-sets?page_size=string")
+      |> json_response(422)
+
+    assert error == "__ERROR__"
+  end
+
+  test "valid page_size param" do
+    get(build_conn(), "/api/v2/data-sets?page_size=501")
+    |> json_response(200)
+  end
 end


### PR DESCRIPTION
- Limit `page_size` param, throw a 422 for invalid arguments
- Drop api controller tests (especially the AOT controller) time by a lot

before (total time 57s)
```
PlenarioWeb.Api.UtilsTest
  * test generates a geospatial query using a bounding box (891.0ms)
  * test generates a ranged query using bounding values (531.0ms)
  * test map_to_query/2 (484.0ms)

PlenarioWeb.Api.AotControllerTest
  * test GET /api/v2/aot (3297.0ms)
  * test GET with filter bbox (3235.0ms)
  * test GET with filter sensor (3234.0ms)

PlenarioWeb.Api.DetailControllerTest
  * test GET /api/v2/data-sets/:slug populates pagination links (1000.0ms)
  * test GET /api/v2/data-sets/:slug bbox query no results (1016.0ms)
  * test GET /api/v2/data-sets/:slug location query (1015.0ms)

PlenarioWeb.Api.ListControllerTest
  * test OPTIONS /api/v2/data-sets headers (750.0ms)
  * test DELETE /api/v2/data-sets status (765.0ms)
  * test GET /api/v2/data-sets with bbox arg (766.0ms)
```

after (total time 36s)
```
PlenarioWeb.Api.UtilsTest
  * test generates a geospatial query using a bounding box (922.0ms)
  * test generates a ranged query using bounding values (641.0ms)
  * test map_to_query/2 (484.0ms)

PlenarioWeb.Api.AotControllerTest
  * test page_size cannot be a string (547.0ms)
  * test GET /api/v2/aot (625.0ms)
  * test valid page_size param (578.0ms)

PlenarioWeb.Api.DetailControllerTest
  * test page_size cannot be a string (516.0ms)
  * test GET /api/v2/data-sets/:slug populates pagination links (531.0ms)
  * test GET /api/v2/data-sets/:slug pagination page parameter (500.0ms)

PlenarioWeb.Api.ListControllerTest
  * test page_size cannot be a string (515.0ms)
  * test OPTIONS /api/v2/data-sets headers (500.0ms)
  * test GET /api/v2/data-sets (531.0ms)
```