### PR TITLE
Json error responses

### DIFF
--- a/lib/plenario_web/controllers/api/plugs.ex
+++ b/lib/plenario_web/controllers/api/plugs.ex
@@ -34,9 +34,8 @@ defmodule PlenarioWeb.Api.Plugs do
         conn
       false ->
         conn
-        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
-        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid value
-        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+        |> put_req_header("accept", "application/vnd.api+json")  # Overwrite the request header to ask for json api content
+        |> Explode.with(422, "Provided page_size '#{page_size}' must be between 0 and #{opts[:page_size_limit]}")
     end
   end
 
@@ -50,9 +49,8 @@ defmodule PlenarioWeb.Api.Plugs do
         with_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
       :error ->
         conn
-        |> put_status(422)  # Indicates request is syntactically correct but unable to be processed.
-        |> json("__ERROR__")  # todo(heyzoos) replace with %Response.Error{} about invalid integer
-        |> halt()  # Breaks the request pipeline and returns the `conn` right away.
+        |> put_req_header("accept", "application/vnd.api+json")  # Overwrite the request header to ask for json api content
+        |> Explode.with(422, "Provided page_size '#{page_size}' must be a number.")
     end
   end
 

--- a/lib/plenario_web/controllers/api/plugs.ex
+++ b/lib/plenario_web/controllers/api/plugs.ex
@@ -34,7 +34,11 @@ defmodule PlenarioWeb.Api.Plugs do
         conn
       false ->
         conn
-        |> put_req_header("accept", "application/vnd.api+json")  # Overwrite the request header to ask for json api content
+        # Even if the request is asking for something else, we only serve json so we overwrite the
+        # header of the incoming request. This will definitely have to be changed later if we want
+        # to serve more than one media type. For most browsers, their default accept header prefers
+        # xml, and this can lead to some weirdly formatted errors.
+        |> put_req_header("accept", "application/vnd.api+json")  
         |> Explode.with(422, "Provided page_size '#{page_size}' must be between 0 and #{opts[:page_size_limit]}")
     end
   end
@@ -49,7 +53,11 @@ defmodule PlenarioWeb.Api.Plugs do
         with_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
       :error ->
         conn
-        |> put_req_header("accept", "application/vnd.api+json")  # Overwrite the request header to ask for json api content
+        # Even if the request is asking for something else, we only serve json so we overwrite the
+        # header of the incoming request. This will definitely have to be changed later if we want
+        # to serve more than one media type. For most browsers, their default accept header prefers
+        # xml, and this can lead to some weirdly formatted errors.
+        |> put_req_header("accept", "application/vnd.api+json")
         |> Explode.with(422, "Provided page_size '#{page_size}' must be a number.")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,12 @@ defmodule Plenario.Mixfile do
       # Result pagination libraries
       {:scrivener, "~> 2.5"},
       {:scrivener_ecto, "~> 1.3"},
+
+      # An easy utility for responding with standard HTTP/JSON error payloads 
+      # in Plug and Phoenix based applications.
+      #
+      # MIT
+      {:explode, "~> 1.0.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.9.6",
+      version: "0.9.7",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,7 @@
   "ex_aws_s3": {:hex, :ex_aws_s3, "2.0.0", "404e7951820d79774cb67b76a1576ad955dcc44773be5a75fbb0b5bc4278a524", [:mix], [{:ex_aws, "~> 2.0.0", [hex: :ex_aws, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.1", "0bbf67f22c7dbf7503981d21a5eef5db8bbc3cb86e70d3798e8c802c74fa5e27", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
+  "explode": {:hex, :explode, "1.0.0", "e9b9acae7a7fe15027a8813b19b8cd424d8747903428ed4ae13c1460aaaa2934", [:mix], [{:ecto, ">= 2.0.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:poison, "~> 2.1 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.4", "f0bdda195c0e46e987333e986452ec523aed21d784189144f647c43eaf307064", [:mix], [], "hexpm"},
   "gen_smtp": {:hex, :gen_smtp, "0.12.0", "97d44903f5ca18ca85cb39aee7d9c77e98d79804bbdef56078adcf905cb2ef00", [:rebar3], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.13.1", "edff5bca9cab22c5d03a834062515e6a1aeeb7665fb44eddae086252e39c4378", [:mix], [], "hexpm"},

--- a/test/plenario_web/controllers/api/aot_controller_test.exs
+++ b/test/plenario_web/controllers/api/aot_controller_test.exs
@@ -239,35 +239,23 @@ defmodule PlenarioWeb.Api.AotControllerTest do
   end
 
   test "page_size param cannot exceed 5000" do
-    error =
-      get(build_conn(), "/api/v2/aot?page_size=5001")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/aot?page_size=5001")
+    |> json_response(422)
   end
 
   test "page_size param cannot be less than 1" do
-    error =
-      get(build_conn(), "/api/v2/aot?page_size=0")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/aot?page_size=0")
+    |> json_response(422)
   end
 
   test "page_size param cannot be negative" do
-    error =
-      get(build_conn(), "/api/v2/aot?page_size=-1")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/aot?page_size=-1")
+    |> json_response(422)
   end
 
   test "page_size cannot be a string" do
-    error =
-      get(build_conn(), "/api/v2/aot?page_size=string")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/aot?page_size=string")
+    |> json_response(422)
   end
 
   test "valid page_size param" do

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -223,35 +223,23 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   end
 
   test "page_size param cannot exceed 5000", %{slug: slug} do
-    error =
-      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=5001")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=5001")
+    |> json_response(422)
   end
 
   test "page_size param cannot be less than 1", %{slug: slug} do
-    error =
-      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=0")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=0")
+    |> json_response(422)
   end
 
   test "page_size param cannot be negative", %{slug: slug} do
-    error =
-      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=-1")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=-1")
+    |> json_response(422)
   end
 
   test "page_size cannot be a string", %{slug: slug} do
-    error =
-      get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=string")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets/#{slug}?page_size=string")
+    |> json_response(422)
   end
 
   test "valid page_size param", %{slug: slug} do

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -185,35 +185,23 @@ defmodule PlenarioWeb.Api.ListControllerTest do
   end
 
   test "page_size param cannot exceed 5000" do
-    error =
-      get(build_conn(), "/api/v2/data-sets?page_size=5001")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets?page_size=5001")
+    |> json_response(422)
   end
 
   test "page_size param cannot be less than 1" do
-    error =
-      get(build_conn(), "/api/v2/data-sets?page_size=0")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets?page_size=0")
+    |> json_response(422)
   end
 
   test "page_size param cannot be negative" do
-    error =
-      get(build_conn(), "/api/v2/data-sets?page_size=-1")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets?page_size=-1")
+    |> json_response(422)
   end
 
   test "page_size cannot be a string" do
-    error =
-      get(build_conn(), "/api/v2/data-sets?page_size=string")
-      |> json_response(422)
-
-    assert error == "__ERROR__"
+    get(build_conn(), "/api/v2/data-sets?page_size=string")
+    |> json_response(422)
   end
 
   test "valid page_size param" do


### PR DESCRIPTION
Set up json error responses (for page size only)

```
// 20180530123551
// http://localhost:4000/api/v2/data-sets?page_size=5001

{
  "errors": [
    {
      "title": "Unprocessable Entity",
      "status": 422,
      "detail": "Provided page_size '5001' must be between 0 and 5000"
    }
  ]
}
```