### PR TITLE
Tempfiles

### DIFF
--- a/lib/plenario/field_guesser.ex
+++ b/lib/plenario/field_guesser.ex
@@ -7,7 +7,7 @@ defmodule Plenario.FieldGuesser do
     Logger.info("beginning download of #{meta.source_url}")
     payload = download!(meta)
 
-    filename = "/tmp/#{meta.slug}.#{meta.source_type}"
+    {:ok, filename} = Briefly.create()
     Logger.info("writing contents to #{filename}")
     :ok = File.write(filename, payload)
 

--- a/lib/plenario_aot/aot_worker.ex
+++ b/lib/plenario_aot/aot_worker.ex
@@ -28,7 +28,7 @@ defmodule PlenarioAot.AotWorker do
   # SERVER IMPLEMENTATION
 
   def handle_call({:process, meta}, _, state) do
-    path = "/tmp/#{meta.slug}.json"
+    {:ok, path} = Briefly.create()
     Logger.info("Starting download for AoT Network `#{meta.network_name}` from `#{meta.source_url}` to `#{path}`")
 
     %HTTPoison.Response{body: body} = HTTPoison.get!(meta.source_url)

--- a/lib/plenario_etl/exporter.ex
+++ b/lib/plenario_etl/exporter.ex
@@ -7,7 +7,6 @@ defmodule PlenarioEtl.Exporter do
   alias PlenarioMailer.Emails
 
   import Plenario.Repo
-  import UUID, only: [uuid4: 0]
 
   require Logger
 
@@ -84,7 +83,7 @@ defmodule PlenarioEtl.Exporter do
   end
 
   defp stream_to_local_storage({job, stream}) do
-    path = "/tmp/#{inspect(uuid4())}"
+    {:ok, path} = Briefly.create()
     file = File.open!(path, [:write, :utf8])
 
     Logger.info("Writing to #{path}")

--- a/lib/plenario_etl/worker.ex
+++ b/lib/plenario_etl/worker.ex
@@ -85,14 +85,9 @@ defmodule PlenarioEtl.Worker do
 
   defp download!(meta) do
     Logger.info("starting source document download")
-    ext =
-      case meta.source_type == "shp" do
-        true -> "zip"
-        false -> meta.source_type
-      end
 
     %HTTPoison.Response{body: body} = HTTPoison.get!(meta.source_url)
-    path = "/tmp/#{meta.slug}.#{ext}"
+    {:ok, path} = Briefly.create()
     File.write!(path, body)
 
     Logger.info("download stored at #{path}")
@@ -130,7 +125,8 @@ defmodule PlenarioEtl.Worker do
   defp load_shp!(path, meta) do
     Logger.info("using shp loader")
 
-    {:ok, file_paths} = :zip.unzip(String.to_charlist(path), cwd: '/tmp/')
+    {:ok, tempdir} = Briefly.create(directory: true)
+    {:ok, file_paths} = :zip.unzip(String.to_charlist(path), cwd: tempdir)
 
     Logger.info("Looking for .shp file")
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,14 @@ defmodule Plenario.Mixfile do
   def application do
     [
       mod: {Plenario.Application, []},
-      extra_applications: [:logger, :runtime_tools, :bamboo, :bamboo_smtp, :sentry]
+      extra_applications: [
+        :bamboo,
+        :bamboo_smtp,
+        :briefly,
+        :logger,
+        :runtime_tools,
+        :sentry
+      ]
     ]
   end
 
@@ -88,7 +95,12 @@ defmodule Plenario.Mixfile do
       # in Plug and Phoenix based applications.
       #
       # MIT
-      {:explode, "~> 1.0.0"}
+      {:explode, "~> 1.0.0"},
+
+      # Simple, robust temporary file support for Elixir.
+      #
+      # Apache 2.0
+      {:briefly, "~> 0.3"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,7 @@ defmodule Plenario.Mixfile do
       # MIT
       {:explode, "~> 1.0.0"},
 
-      # Simple, robust temporary file support for Elixir.
+      # Utility for temporary file handling and cleanup.
       #
       # Apache 2.0
       {:briefly, "~> 0.3"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plenario.Mixfile do
   def project do
     [
       app: :plenario,
-      version: "0.10.0",
+      version: "0.10.1",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "bamboo_smtp": {:hex, :bamboo_smtp, "1.4.0", "a01d91406f3a46b3452c84d345d50f75d6facca5e06337358287a97da0426240", [:mix], [{:bamboo, "~> 0.8.0", [hex: :bamboo, repo: "hexpm", optional: false]}, {:gen_smtp, "~> 0.12.0", [hex: :gen_smtp, repo: "hexpm", optional: false]}], "hexpm"},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "1.0.6", "58a865939b3106d5ad4841f660955b958be6db955dda034fbbc1069dbacb97fa", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
   "canada": {:hex, :canada, "1.0.2", "040e4c47609b0a67d5773ac1fbe5e99f840cef173d69b739beda7c98453e0770", [:mix], [], "hexpm"},
   "canary": {:hex, :canary, "1.1.1", "4138d5e05db8497c477e4af73902eb9ae06e49dceaa13c2dd9f0b55525ded48b", [:mix], [{:canada, "~> 1.0.1", [hex: :canada, repo: "hexpm", optional: false]}, {:ecto, ">= 1.1.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Small quality of life PR for developing on non linux OSs.

The way we handled temporary files before is with hardcoded `"/tmp"` strings, all this PR does is use the tempfile directory provided at `TEMP` (windows), `TMPDIR` (mac), or `TMP` (linux) before falling back to "/tmp". We now also clean the temp files up after the host process terminates.

Next up are those damn `ModelRegistry` lookup failures