### PR TITLE
Added a Dockerignore File

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 _build/
 .elixir_ls/
 .git/
-assests/node_modules/
+assets/node_modules/
 deps/
 priv/static/
 test/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+_build/
+.elixir_ls/
+.git/
+assests/node_modules/
+deps/
+priv/static/
+test/
+.formatter.exs
+.gitignore
+.travis.yml
+Apache2-License.txt
+build
+coveralls.json
+deploy
+LICENSE
+README.md

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.11.2"
+  @version "0.11.3"
 
   def project do
     [


### PR DESCRIPTION
I mean, why didn't we have one before? I noticed my builds were taking
forever and the context being sent was **gianormous**.

This ignores pretty much everything except the bare bones of what's
needed to build the executable.