### PR TITLE
Ingest Bug Fix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.11.4"
+  @version "0.11.5"
 
   def project do
     [

--- a/priv/db-actions/etl/copy.sql.eex
+++ b/priv/db-actions/etl/copy.sql.eex
@@ -1,3 +1,8 @@
 COPY "<%= table_name %>"
-("<%= headers %>")
+<% len_headers = length(headers) %>
+(
+  <%= for {h, idx} <- Enum.with_index(headers, 1) do %>
+  "<%= h %>"<%= if idx < len_headers do %>,<% end %>
+  <% end %>
+)
 FROM STDIN USING DELIMITERS '<%= delimiter %>' CSV HEADER;


### PR DESCRIPTION
We were having an issue consuming a few data sets. After some
investigation, I discovered that it was due to quotes being used in
header rows:

```
One,Two,"Three, or three",Four
```

This would then be translated into the Copy SQL as:

```
COPY ... ("One", "Two", ""Three, or three"", "Four") ...
```

which obviously isn't going to work.

The solution is to _regex_ split the header line rather than the naive
_string_ split. But you may ask, "Why do splits at all? Can't we just
use the CSV module and pull the keys from the first map row?". The
unfortunate answer to this is that the CSV module does not preserve
order -- if you have a header row `a,c,b` then you will get a map with
keys ordered as `a,b,c`. To preserve the order of the headers, you need
to split the line.

Fixes #344