### PR TITLE
Shim endpoint response formatting

### DIFF
--- a/lib/plenario_web/controllers/api/shim_controller.ex
+++ b/lib/plenario_web/controllers/api/shim_controller.ex
@@ -76,7 +76,10 @@ defmodule PlenarioWeb.Api.ShimController do
   as the query will not be valid.
   """
   def adapt_location_geom(conn = %Conn{params: %{"location_geom" => geom}}) do
-    meta = MetaActions.get(conn.params["slug"], with_virtual_points: true)
+    meta = MetaActions.get(conn.params["slug"], 
+      with_data_set_fields: true,
+      with_virtual_points: true,
+      with_virtual_dates: true)
     
     # Snips off the `within` prefix of the geometry. This is so that later on
     # we can prepend the V2 compliant `in` keyword.

--- a/lib/plenario_web/controllers/api/shim_controller.ex
+++ b/lib/plenario_web/controllers/api/shim_controller.ex
@@ -15,7 +15,7 @@ defmodule PlenarioWeb.Api.ShimController do
   """
   def datasets(conn, _) do
     %{conn | params: translate(conn.params)}
-    |> PlenarioWeb.Api.ListController.call(:get)
+    |> PlenarioWeb.Api.ListController.call(:describe)
   end
 
   @doc """
@@ -76,11 +76,11 @@ defmodule PlenarioWeb.Api.ShimController do
   as the query will not be valid.
   """
   def adapt_location_geom(conn = %Conn{params: %{"location_geom" => geom}}) do
-    meta = MetaActions.get(conn.params["slug"], 
+    meta = MetaActions.get(conn.params["slug"],
       with_data_set_fields: true,
       with_virtual_points: true,
       with_virtual_dates: true)
-    
+
     # Snips off the `within` prefix of the geometry. This is so that later on
     # we can prepend the V2 compliant `in` keyword.
     [_, geom] = String.split(geom, ":", parts: 2)

--- a/lib/plenario_web/views/api/detail_view.ex
+++ b/lib/plenario_web/views/api/detail_view.ex
@@ -28,12 +28,7 @@ defmodule PlenarioWeb.Api.DetailView do
   end
 
   def render("get.json", params) do
-    response = construct_response(params)
-    if length(params[:data]) == 1 do
-      %{response | data: clean(List.first(params[:data]))}
-    else
-      %{response | data: clean(params[:data])}
-    end
+    %{construct_response(params) | data: clean(params[:data])}
   end
 
   @doc """

--- a/lib/plenario_web/views/api/shim_view.ex
+++ b/lib/plenario_web/views/api/shim_view.ex
@@ -1,3 +1,22 @@
 defmodule PlenarioWeb.Api.ShimView do
-  def render("get.json", params), do: PlenarioWeb.Api.ListView.render("get.json", params)
+  require Logger
+
+  import PlenarioWeb.Api.DetailView, only: [clean: 1]
+
+  # todo(heyzoos) refactor what gets passed in as params
+  #   - Currently I just toss the whole kitchen sink at you and say:
+  #     "From this pile of shit construct a meaningful response"
+  #   - It would be nice if we formalized this as a struct with just
+  #     the necessary information
+  def render("get.json", params) do 
+    %{
+      meta: %{
+        message: "",
+        total: params[:total_records],
+        query: params[:params],
+        status: "ok"
+      },
+      objects: clean(params[:data])
+    }
+  end
 end

--- a/lib/plenario_web/views/api/shim_view.ex
+++ b/lib/plenario_web/views/api/shim_view.ex
@@ -1,6 +1,7 @@
 defmodule PlenarioWeb.Api.ShimView do
   require Logger
 
+  alias Plenario.Schemas.Meta
   import PlenarioWeb.Api.DetailView, only: [clean: 1]
 
   # todo(heyzoos) refactor what gets passed in as params
@@ -8,7 +9,11 @@ defmodule PlenarioWeb.Api.ShimView do
   #     "From this pile of shit construct a meaningful response"
   #   - It would be nice if we formalized this as a struct with just
   #     the necessary information
-  def render("get.json", params) do 
+  def render("datasets.json", params) do
+    render("detail.json", %{params | data: translate_meta(params[:data])})
+  end
+
+  def render("detail.json", params) do 
     %{
       meta: %{
         message: "",
@@ -18,5 +23,52 @@ defmodule PlenarioWeb.Api.ShimView do
       },
       objects: clean(params[:data])
     }
+  end
+
+  def translate_metas(metas) do
+    columns = meta.fields |> format_columns() |> Enum.sort()
+    location = Enum.find(meta.virtual_point_fields, fn field -> not is_nil(field) end)
+    observed_date = Enum.find(columns, fn field -> field.type == "DATE" end)
+
+    Enum.map(metas, fn meta ->
+      %{
+        bbox: meta.bbox,
+        columns: columns,
+        latitude: nil,
+        obs_from: meta.time_range["lower"],
+        observed_date: observed_date,
+        obs_to: meta.time_range["upper"]
+        view_url: nil,
+        description: meta.description,
+        attribution: meta.attribution,
+        longitude: nil,
+        source_url: meta.source_url,
+        human_name: meta.,
+        dataset_name: meta.slug,
+        date_added: meta.inserted_at,
+        last_update: meta.latest_import,
+        update_freq: meta.refresh_rate,
+        location: location
+      }
+    end)
+  end
+
+  #   - Need to select first location column
+  #   -   Sort and grab
+  #   - Need to select first datetime column
+  #   -   Sort and grab
+
+  def translate_meta(meta = %Meta{}) do
+    %{
+      bbox: meta.bbox,
+      latitude: meta.
+    }
+  end
+
+  # This needs to map to expected types
+  def format_columns(columns) do
+    Enum.map(columns, fn column -> 
+      %{field_name: column.name, field_type: column.type}
+    end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.11.6"
+  @version "0.11.7"
 
   def project do
     [

--- a/test/plenario_web/controllers/api/detail_controller_test.exs
+++ b/test/plenario_web/controllers/api/detail_controller_test.exs
@@ -68,7 +68,7 @@ defmodule PlenarioWeb.Api.DetailControllerTest do
   test "GET /api/v2/data-sets/:slug/@head", %{slug: slug} do
     conn = get(build_conn(), "/api/v2/data-sets/#{slug}/@head")
     response = json_response(conn, 200)
-    assert is_map(response["data"])
+    assert is_list(response["data"])
   end
 
   test "GET /api/v2/data-sets/:slug/@describe", %{slug: slug} do

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -101,7 +101,7 @@ defmodule PlenarioWeb.Api.ListControllerTest do
   test "GET /api/v2/data-sets/@head", %{conn: conn} do
     conn = get(conn, "/api/v2/data-sets/@head")
     result = json_response(conn, 200)
-    assert is_map(result["data"])
+    assert is_list(result["data"])
   end
 
   test "GET /api/v2/data-sets/@describe", %{conn: conn} do

--- a/test/plenario_web/controllers/api/shim_controller_test.exs
+++ b/test/plenario_web/controllers/api/shim_controller_test.exs
@@ -131,13 +131,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__ge=2500-01-01T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 15
+    assert length(result["objects"]) == 15
   
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__ge=2500-01-02T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 10
+    assert length(result["objects"]) == 10
   end
 
   test "GET /v1/api/detail __gt", %{conn: conn, meta: meta} do
@@ -145,13 +145,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__gt=2500-01-01T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 10
+    assert length(result["objects"]) == 10
   
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__gt=2500-01-02T00:00:00")
       |> json_response(200)
   
-    assert result["meta"]["counts"]["total_records"] == 1
+    assert result["meta"]["total"] == 1
   end
 
   test "GET /v1/api/detail __lt", %{conn: conn, meta: meta} do
@@ -159,13 +159,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__lt=2500-01-01T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 0
+    assert length(result["objects"]) == 0
   
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__lt=2500-01-02T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 5
+    assert length(result["objects"]) == 5
   end
 
   test "GET /v1/api/detail __le", %{conn: conn, meta: meta} do
@@ -173,13 +173,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__le=2500-01-01T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 5
+    assert length(result["objects"]) == 5
   
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__le=2500-01-02T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 14
+    assert length(result["objects"]) == 14
   end
 
   test "GET /api/v1/detail __eq", %{conn: conn, meta: meta} do
@@ -187,42 +187,42 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__eq=2500-01-02T00:00:00")
       |> json_response(200)
   
-    assert length(result["data"]) == 9 
+    assert length(result["objects"]) == 9 
   end
 
   test "GET /v1/api/datasets", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets"), 200)
-    assert length(result["data"]) == 6
+    assert length(result["objects"]) == 6
   end
 
   test "GET /api/v1/datasets has correct count", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets"), 200)
-    assert result["meta"]["counts"]["total_records"] == 6
+    assert result["meta"]["total"] == 6
   end
 
   test "GET /v1/api/datasets __ge", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets?latest_import__ge=2000-01-03T00:00:00"), 200)
-    assert result["meta"]["counts"]["total_records"] == 4
+    assert result["meta"]["total"] == 4
   end
 
   test "GET /v1/api/datasets __gt", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets?latest_import__gt=2000-01-03T00:00:00"), 200)
-    assert result["meta"]["counts"]["total_records"] == 3
+    assert result["meta"]["total"] == 3
   end
 
   test "GET /v1/api/datasets __le", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets?latest_import__le=2000-01-03T00:00:00"), 200)
-    assert result["meta"]["counts"]["total_records"] == 3
+    assert result["meta"]["total"] == 3
   end
 
   test "GET /v1/api/datasets __lt", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets?latest_import__lt=2000-01-03T00:00:00"), 200)
-    assert result["meta"]["counts"]["total_records"] == 2
+    assert result["meta"]["total"] == 2
   end
 
   test "GET /v1/api/datasets __eq", %{conn: conn} do
     result = json_response(get(conn, "/api/v1/datasets?latest_import__eq=2000-01-03T00:00:00"), 200)
-    assert result["meta"]["counts"]["total_records"] == 1
+    assert result["meta"]["total"] == 1
   end
 
   test "GET /v1/api/detail obs_date", %{conn: conn, meta: meta} do
@@ -233,8 +233,8 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "&obs_date__le=2500-01-01T00:00:00")
       |> json_response(200)
     
-    assert result["meta"]["counts"]["total_records"] == 5
-    assert length(result["data"]) == 5
+    assert result["meta"]["total"] == 5
+    assert length(result["objects"]) == 5
   end
 
   test "GET /v1/api/detail location_geom__within", %{conn: conn, meta: meta} do
@@ -261,8 +261,8 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "&location_geom__within=#{geom}")
       |> json_response(200)
     
-    assert result["meta"]["counts"]["total_records"] == 10
-    assert length(result["data"]) == 10 
+    assert result["meta"]["total"] == 10
+    assert length(result["objects"]) == 10 
   end
 
   test "GET /v1/api/detail obs_date & geom", %{conn: conn, meta: meta} do
@@ -290,6 +290,6 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "&obs_date__ge=2500-01-03T00:00:00")
       |> json_response(200)
     
-    assert result["meta"]["counts"]["total_records"] == 1
+    assert result["meta"]["total"] == 1
   end
 end

--- a/test/plenario_web/controllers/api/shim_controller_test.exs
+++ b/test/plenario_web/controllers/api/shim_controller_test.exs
@@ -130,13 +130,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__ge=2500-01-01T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 15
-  
+
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__ge=2500-01-02T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 10
   end
 
@@ -144,13 +144,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__gt=2500-01-01T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 10
-  
+
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__gt=2500-01-02T00:00:00")
       |> json_response(200)
-  
+
     assert result["meta"]["total"] == 1
   end
 
@@ -158,13 +158,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__lt=2500-01-01T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 0
-  
+
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__lt=2500-01-02T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 5
   end
 
@@ -172,13 +172,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__le=2500-01-01T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 5
-  
+
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__le=2500-01-02T00:00:00")
       |> json_response(200)
-  
+
     assert length(result["objects"]) == 14
   end
 
@@ -186,8 +186,8 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
     result =
       get(conn, "/v1/api/detail?dataset_name=#{meta.slug}&datetime__eq=2500-01-02T00:00:00")
       |> json_response(200)
-  
-    assert length(result["objects"]) == 9 
+
+    assert length(result["objects"]) == 9
   end
 
   test "GET /v1/api/datasets", %{conn: conn} do
@@ -232,13 +232,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "?dataset_name=#{meta.slug}"
         <> "&obs_date__le=2500-01-01T00:00:00")
       |> json_response(200)
-    
+
     assert result["meta"]["total"] == 5
     assert length(result["objects"]) == 5
   end
 
   test "GET /v1/api/detail location_geom__within", %{conn: conn, meta: meta} do
-    geom = 
+    geom =
       """
       {
         "type":"Polygon",
@@ -260,13 +260,13 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "?dataset_name=#{meta.slug}"
         <> "&location_geom__within=#{geom}")
       |> json_response(200)
-    
+
     assert result["meta"]["total"] == 10
-    assert length(result["objects"]) == 10 
+    assert length(result["objects"]) == 10
   end
 
   test "GET /v1/api/detail obs_date & geom", %{conn: conn, meta: meta} do
-    geom = 
+    geom =
       """
       {
         "type":"Polygon",
@@ -289,7 +289,21 @@ defmodule PlenarioWeb.Api.ShimControllerTest do
         <> "&location_geom__within=#{geom}"
         <> "&obs_date__ge=2500-01-03T00:00:00")
       |> json_response(200)
-    
+
     assert result["meta"]["total"] == 1
+  end
+
+  test "V1 format special columns for metas at /datasets endpoint", %{vpf: vpf} do
+    result =
+      build_conn()
+      |> get("/api/v1/datasets")
+      |> json_response(200)
+
+    meta = Enum.find(result["objects"], fn
+      m -> m["dataset_name"] == "api-test-dataset"
+    end)
+
+    assert meta["observed_date"] == "datetime"
+    assert meta["location"] == vpf.name
   end
 end


### PR DESCRIPTION
- Formats V2 responses to show up like V1 responses
  - There's a little bit of janky trickery to make this work, specifically for providing "special" V1 columns
  - Have to grab first location and datetime columns since there is no notion of `observed_date` column or `location` column in V2
- For all responses, data is always returned as a list. There was a special case where if the length of the data was 1, it just returned an object. But we had a discussion a while back as to why that was a bad idea, so I've fixed it in this PR
