### PR TITLE
Bump min node-sass version to avoid vulnerability

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -34,7 +34,7 @@
     "jquery": "^3.3.1",
     "leaflet": "^1.3.1",
     "leaflet-draw": "^1.0.2",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.9.1",
     "pikaday": "^1.7.0",
     "popper.js": "^1.14.3",
     "postcss-cssnext": "^3.1.0",

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.11.9"
+  @version "0.11.10"
 
   def project do
     [


### PR DESCRIPTION
Our existing semver for this package is generally sufficient, since the fix was pushed in node-sass 4.9.1 and we depend on ^4.9.0, but this ensures NPM won't pull the vulnerable 4.9.0 anyway when deduping

This will be a patch version bump, since the only direct change in node-sass is to bump their own dependency that was locking in the vulnerable package. I'm guessing it will be 0.12.1, but I'll resolve that when it comes time to merge this.

Closes #307.