### PR TITLE
362 index names

### DIFF
--- a/lib/plenario/actions/data_set_actions.ex
+++ b/lib/plenario/actions/data_set_actions.ex
@@ -29,20 +29,20 @@ defmodule Plenario.Actions.DataSetActions do
     table_name = meta.table_name
     view_name = "#{table_name}_view"
 
-    text_fields = Enum.filter(fields, & &1.type == "text") |> Enum.map(& &1.name)
-    boolean_fields = Enum.filter(fields, & &1.type == "boolean") |> Enum.map(& &1.name)
-    integer_fields = Enum.filter(fields, & &1.type == "integer") |> Enum.map(& &1.name)
-    float_fields = Enum.filter(fields, & &1.type == "float") |> Enum.map(& &1.name)
-    timestamp_fields = Enum.filter(fields, & &1.type == "timestamp") |> Enum.map(& &1.name)
+    text_fields = Enum.filter(fields, & &1.type == "text")
+    boolean_fields = Enum.filter(fields, & &1.type == "boolean")
+    integer_fields = Enum.filter(fields, & &1.type == "integer")
+    float_fields = Enum.filter(fields, & &1.type == "float")
+    timestamp_fields = Enum.filter(fields, & &1.type == "timestamp")
 
     gin_index_fields =
       boolean_fields ++
       integer_fields ++
       float_fields ++
       timestamp_fields ++
-      Enum.map(virtual_dates, & &1.name)
+      virtual_dates
 
-    gist_index_fields = Enum.map(virtual_points, & &1.name)
+    gist_index_fields = virtual_points
 
     tsvector_index_fields = text_fields
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.12.1"
 
   def project do
     [

--- a/priv/db-actions/up/create-index.sql.eex
+++ b/priv/db-actions/up/create-index.sql.eex
@@ -1,3 +1,4 @@
-CREATE INDEX ON "<%= view_name %>"
+CREATE INDEX "idx_<%= view_name %>_<%= field.id %>"
+ON "<%= view_name %>"
 <%= if using do %>USING <%= using %><% end %>
-("<%= field %>");
+("<%= field.name %>");

--- a/priv/db-actions/up/create-trgm-index.sql.eex
+++ b/priv/db-actions/up/create-trgm-index.sql.eex
@@ -1,3 +1,3 @@
-CREATE INDEX "<%= view_name %>_<%= field %>_tsvector"
+CREATE INDEX "idx_<%= view_name %>_<%= field.id %>"
 ON "<%= view_name %>"
-USING GIN ( to_tsvector('english', "<%= field %>") )
+USING GIN ( to_tsvector('english', "<%= field.name %>") )

--- a/priv/db-actions/up/create-view.sql.eex
+++ b/priv/db-actions/up/create-view.sql.eex
@@ -4,27 +4,27 @@ SELECT
 
   -- text fields
   <%= for f <- text_fields do %>
-  , "<%= f %>"
+  , "<%= f.name %>"
   <% end %>
 
   -- boolean fields
   <%= for f <- boolean_fields do %>
-  , p_boolean_from_text("<%= f %>") AS "<%= f %>"
+  , p_boolean_from_text("<%= f.name %>") AS "<%= f.name %>"
   <% end %>
 
   -- integer fields
   <%= for f <- integer_fields do %>
-  , p_integer_from_text("<%= f %>") AS "<%= f %>"
+  , p_integer_from_text("<%= f.name %>") AS "<%= f.name %>"
   <% end %>
 
   -- float fields
   <%= for f <- float_fields do %>
-  , p_float_from_text("<%= f %>") AS "<%= f %>"
+  , p_float_from_text("<%= f.name %>") AS "<%= f.name %>"
   <% end %>
 
   -- timestmap fields
   <%= for f <- timestamp_fields do %>
-  , p_timestamp_from_text("<%= f %>") AS "<%= f %>"
+  , p_timestamp_from_text("<%= f.name %>") AS "<%= f.name %>"
   <% end %>
 
   -- virtual dates

--- a/test/plenario/actions/data_set_actions_test.exs
+++ b/test/plenario/actions/data_set_actions_test.exs
@@ -6,6 +6,7 @@ defmodule Plenario.Actions.DataSetActionsTest do
   alias Plenario.Actions.{
     DataSetActions,
     DataSetFieldActions,
+    MetaActions,
     VirtualPointFieldActions
   }
 
@@ -70,5 +71,20 @@ defmodule Plenario.Actions.DataSetActionsTest do
         }
       end
     end
+  end
+
+  # for some data sets, the name of the data set and the names of its
+  # fields when concatenated overrun the maximum length of index names
+  # for postgres. when this happens, the name of the index is
+  # truncated and we run into naming collisions. this test ensures that
+  # each index is given a unique name, even in the event of an overflow
+  # and truncation.
+  test "up! with really long names", %{meta: meta} do
+    {:ok, meta} = MetaActions.update(meta, name: "blah blah blah blah blah blah blah blah blah blah blah blah blah")
+    {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 1", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 2", "text")
+    {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 3", "text")
+
+    :ok = DataSetActions.up!(meta)
   end
 end


### PR DESCRIPTION
### Explicitly Name Indexes

We ran into an issue where data sets with long names and with
long, similarly named fields would result in naming collisions when
creating indexes. When a name exceeds a certain length, postgres
truncates it. When this happens, we wind up with naming collisions and
bring up the table/view/indexes for the data set fails.

Fixes #362