### PR TITLE
331 maps

### DIFF
--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -316,10 +316,13 @@ defmodule Plenario.Actions.MetaActions do
   def get_points(meta, limit \\ 1_000) do
     meta = get(meta.id, with_virtual_points: true)
 
-    pt =
-      meta.virtual_points
-      |> List.first()
+    meta.virtual_points
+    |> List.first()
+    |> do_get_points(meta, limit)
+  end
 
+  defp do_get_points(nil, _, _), do: []
+  defp do_get_points(pt, meta, limit) do
     # we need to use a raw query here to harness the
     # tablesample selection in postgres.
     query =

--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -331,5 +331,9 @@ defmodule Plenario.Actions.MetaActions do
     %Postgrex.Result{rows: data} = Repo.query!(query)
 
     List.flatten(data)
+    |> Enum.reject(& is_nil(&1))
+    |> Enum.map(fn %Geo.Point{coordinates: {lon, lat}} ->
+      "[#{lat}, #{lon}]"
+    end)
   end
 end

--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -312,4 +312,24 @@ defmodule Plenario.Actions.MetaActions do
     model = ModelRegistry.lookup(meta.slug)
     Repo.one(from m in model, select: fragment("count(*)"))
   end
+
+  def get_points(meta, limit \\ 1_000) do
+    meta = get(meta.id, with_virtual_points: true)
+
+    pt =
+      meta.virtual_points
+      |> List.first()
+
+    # we need to use a raw query here to harness the
+    # tablesample selection in postgres.
+    query =
+      """
+      SELECT #{inspect(pt.name)}
+      FROM "#{meta.table_name}_view"
+      TABLESAMPLE SYSTEM_ROWS(#{limit});
+      """
+    %Postgrex.Result{rows: data} = Repo.query!(query)
+
+    List.flatten(data)
+  end
 end

--- a/lib/plenario_web/controllers/web/data_set_controller.ex
+++ b/lib/plenario_web/controllers/web/data_set_controller.ex
@@ -34,12 +34,7 @@ defmodule PlenarioWeb.Web.DataSetController do
         _ -> user.id == meta.user_id
       end
 
-    points =
-      MetaActions.get_points(meta)
-      |> Enum.reject(& is_nil(&1))
-      |> Enum.map(fn %Geo.Point{coordinates: {lon, lat}} ->
-        "[#{lat}, #{lon}]"
-      end)
+    points = MetaActions.get_points(meta)
 
     render(conn, "show.html",
       meta: meta,

--- a/lib/plenario_web/controllers/web/data_set_controller.ex
+++ b/lib/plenario_web/controllers/web/data_set_controller.ex
@@ -34,13 +34,21 @@ defmodule PlenarioWeb.Web.DataSetController do
         _ -> user.id == meta.user_id
       end
 
+    points =
+      MetaActions.get_points(meta)
+      |> Enum.reject(& is_nil(&1))
+      |> Enum.map(fn %Geo.Point{coordinates: {lon, lat}} ->
+        "[#{lat}, #{lon}]"
+      end)
+
     render(conn, "show.html",
       meta: meta,
       virtual_dates: virtual_dates,
       virtual_points: virtual_points,
       charts: charts,
       disabled?: disabled?,
-      user_is_owner?: user_is_owner?
+      user_is_owner?: user_is_owner?,
+      points: points
     )
   end
 

--- a/lib/plenario_web/templates/shared/map.html.eex
+++ b/lib/plenario_web/templates/shared/map.html.eex
@@ -34,37 +34,37 @@
 
   // handle drawing events
   map.on('draw:created', function (e) {
-    var latLongs = e.layer.getLatLngs();
+    let latLongs = e.layer.getLatLngs();
     latLongs = latLongs[0];
 
-    var coords = [];
-    for (var i = 0; i < latLongs.length; i++) {
-      var el = latLongs[i];
+    let coords = [];
+    for (let i = 0; i < latLongs.length; i++) {
+      let el = latLongs[i];
       coords.push([
         el.lat,
         el.lng
       ]);
     }
 
-    var coordInput = document.getElementById('<%= @form_input_coords %>');
+    let coordInput = document.getElementById('<%= @form_input_coords %>');
     coordInput.value = JSON.stringify(coords);
     drawnItems.addLayer(e.layer);
   });
 
-  map.on('draw:devared', function (e) {
-    var coordInput = document.getElementById('<%= @form_input_coords %>');
+  map.on('draw:deleted', function (e) {
+    let coordInput = document.getElementById('<%= @form_input_coords %>');
     coordInput.value = '';
     drawnItems.clearLayers(e.layer);
   });
 
   // setup form submit listener
   $('form:first').submit(function (e) {
-    var coordInput = document.getElementById('<%= @form_input_coords %>');
-    var zoomInput = document.getElementById('<%= @form_input_zoom %>');
+    let coordInput = document.getElementById('<%= @form_input_coords %>');
+    let zoomInput = document.getElementById('<%= @form_input_zoom %>');
 
     if (!coordInput.value.match(/^\[\[.*\]\]/)) {
       // set coords to entire map view and set zoom to 1 out
-      var bounds = map.getBounds();
+      let bounds = map.getBounds();
       coordInput.value = JSON.stringify(bounds);
       zoomInput.value = map.getBoundsZoom(bounds, true) - 1;
     } else {
@@ -81,7 +81,7 @@
   <% end %>
 
   <%= if @points do %>
-    var markerOpts = {
+    let markerOpts = {
       radius: 5,
       color: "#fff",
       weight: 2,
@@ -90,14 +90,14 @@
     };
 
     <%= for {{pt, name, node_id}, idx} <- Enum.with_index(@points) do %>
-      var pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
       pt_<%= idx %>.bindPopup("<strong>Node <%= node_id %><br>Located at <%= name %></strong><br><%= pt %>");
       pt_<%= idx %>.addTo(map);
     <% end %>
   <% end %>
 
   <%= if @ds_points do %>
-    var markerOpts = {
+    let markerOpts = {
       radius: 5,
       color: "#fff",
       weight: 2,
@@ -106,7 +106,7 @@
     };
 
     <%= for {pt, idx} <- Enum.with_index(@ds_points) do %>
-      var pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
       pt_<%= idx %>.addTo(map);
     <% end %>
   <% end %>

--- a/lib/plenario_web/templates/shared/map.html.eex
+++ b/lib/plenario_web/templates/shared/map.html.eex
@@ -81,17 +81,33 @@
   <% end %>
 
   <%= if @points do %>
-  const markerOpts = {
-    radius: 5,
-    color: "#fff",
-    weight: 2,
-    fillColor: "#dc3545",
-    fillOpacity: 1,
-  };
-  <%= for {{pt, name, node_id}, idx} <- Enum.with_index(@points) do %>
-  let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
-  pt_<%= idx %>.bindPopup("<strong>Node <%= node_id %><br>Located at <%= name %></strong><br><%= pt %>");
-  pt_<%= idx %>.addTo(map);
+    const markerOpts = {
+      radius: 5,
+      color: "#fff",
+      weight: 2,
+      fillColor: "#dc3545",
+      fillOpacity: 1,
+    };
+
+    <%= for {{pt, name, node_id}, idx} <- Enum.with_index(@points) do %>
+      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      pt_<%= idx %>.bindPopup("<strong>Node <%= node_id %><br>Located at <%= name %></strong><br><%= pt %>");
+      pt_<%= idx %>.addTo(map);
+    <% end %>
   <% end %>
+
+  <%= if @ds_points do %>
+    const markerOpts = {
+      radius: 5,
+      color: "#fff",
+      weight: 2,
+      fillColor: "#dc3545",
+      fillOpacity: 1,
+    };
+
+    <%= for {pt, idx} <- Enum.with_index(@ds_points) do %>
+      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      pt_<%= idx %>.addTo(map);
+    <% end %>
   <% end %>
 </script>

--- a/lib/plenario_web/templates/shared/map.html.eex
+++ b/lib/plenario_web/templates/shared/map.html.eex
@@ -2,8 +2,8 @@
 
 <script defer>
   // instantiate the map
-  const mapId = '<%= @map_id %>';
-  let map = L.map(mapId).setView(<%= @map_center %>, <%= @map_zoom %>);
+  var mapId = '<%= @map_id %>';
+  var map = L.map(mapId).setView(<%= @map_center %>, <%= @map_zoom %>);
   L.tileLayer(
     'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
     {
@@ -14,12 +14,12 @@
   ).addTo(map);
 
   // add layer for items drawn to map
-  let drawnItems = new L.FeatureGroup();
+  var drawnItems = new L.FeatureGroup();
   map.addLayer(drawnItems);
 
   <%= if @draw_controls do %>
   // add the shape drawing controls to the map
-  let drawControl = new L.Control.Draw({
+  var drawControl = new L.Control.Draw({
     edit: {
       featureGroup: drawnItems
     },
@@ -34,10 +34,10 @@
 
   // handle drawing events
   map.on('draw:created', function (e) {
-    let latLongs = e.layer.getLatLngs();
+    var latLongs = e.layer.getLatLngs();
     latLongs = latLongs[0];
 
-    let coords = [];
+    var coords = [];
     for (var i = 0; i < latLongs.length; i++) {
       var el = latLongs[i];
       coords.push([
@@ -46,25 +46,25 @@
       ]);
     }
 
-    let coordInput = document.getElementById('<%= @form_input_coords %>');
+    var coordInput = document.getElementById('<%= @form_input_coords %>');
     coordInput.value = JSON.stringify(coords);
     drawnItems.addLayer(e.layer);
   });
 
-  map.on('draw:deleted', function (e) {
-    let coordInput = document.getElementById('<%= @form_input_coords %>');
+  map.on('draw:devared', function (e) {
+    var coordInput = document.getElementById('<%= @form_input_coords %>');
     coordInput.value = '';
     drawnItems.clearLayers(e.layer);
   });
 
   // setup form submit listener
   $('form:first').submit(function (e) {
-    let coordInput = document.getElementById('<%= @form_input_coords %>');
-    let zoomInput = document.getElementById('<%= @form_input_zoom %>');
+    var coordInput = document.getElementById('<%= @form_input_coords %>');
+    var zoomInput = document.getElementById('<%= @form_input_zoom %>');
 
     if (!coordInput.value.match(/^\[\[.*\]\]/)) {
       // set coords to entire map view and set zoom to 1 out
-      let bounds = map.getBounds();
+      var bounds = map.getBounds();
       coordInput.value = JSON.stringify(bounds);
       zoomInput.value = map.getBoundsZoom(bounds, true) - 1;
     } else {
@@ -77,11 +77,11 @@
   <% end %>
 
   <%= if @bbox do %>
-  let bbox = L.polygon(<%= @bbox %>).addTo(map);
+  var bbox = L.polygon(<%= @bbox %>).addTo(map);
   <% end %>
 
   <%= if @points do %>
-    const markerOpts = {
+    var markerOpts = {
       radius: 5,
       color: "#fff",
       weight: 2,
@@ -90,14 +90,14 @@
     };
 
     <%= for {{pt, name, node_id}, idx} <- Enum.with_index(@points) do %>
-      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      var pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
       pt_<%= idx %>.bindPopup("<strong>Node <%= node_id %><br>Located at <%= name %></strong><br><%= pt %>");
       pt_<%= idx %>.addTo(map);
     <% end %>
   <% end %>
 
   <%= if @ds_points do %>
-    const markerOpts = {
+    var markerOpts = {
       radius: 5,
       color: "#fff",
       weight: 2,
@@ -106,7 +106,7 @@
     };
 
     <%= for {pt, idx} <- Enum.with_index(@ds_points) do %>
-      let pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
+      var pt_<%= idx %> = L.circleMarker(<%= pt %>, markerOpts);
       pt_<%= idx %>.addTo(map);
     <% end %>
   <% end %>

--- a/lib/plenario_web/templates/web/data_set/show.html.eex
+++ b/lib/plenario_web/templates/web/data_set/show.html.eex
@@ -83,7 +83,8 @@
     <div class="col-lg-6">
       <h3>Map</h3>
       <%= PlenarioWeb.SharedView.render_map(
-        bbox: Plenario.Actions.MetaActions.dump_bbox(@meta)
+        bbox: Plenario.Actions.MetaActions.dump_bbox(@meta),
+        ds_points: @points
       )%>
     </div>
   </div>

--- a/lib/plenario_web/templates/web/page/explorer.html.eex
+++ b/lib/plenario_web/templates/web/page/explorer.html.eex
@@ -100,6 +100,13 @@
           </p>
         </div>
         <div class="col-lg-9">
+          <%= if length(res.charts) == 0 do %>
+            <%= PlenarioWeb.SharedView.render_map(
+              bbox: Plenario.Actions.MetaActions.dump_bbox(res),
+              ds_points: Plenario.Actions.MetaActions.get_points(res),
+              map_id: "ds_#{res.id}_map"
+            )%>
+          <% end %>
           <%= for chart <- res.charts do %>
           <div
             id="chart-<%= chart.id %>"

--- a/lib/plenario_web/views/shared_view.ex
+++ b/lib/plenario_web/views/shared_view.ex
@@ -4,14 +4,15 @@ defmodule PlenarioWeb.SharedView do
   def render_map(opts \\ []) do
     defaults = [
       map_id: "map",
-      map_height: 500,
+      map_height: "50vw",
       map_center: "[41.9, -87.7]",
       map_zoom: 10,
       draw_controls: false,
       form_input_coords: "coords",
       form_input_zoom: "zoom",
       bbox: nil,
-      points: nil
+      points: nil,
+      ds_points: nil
     ]
     assigns = Keyword.merge(defaults, opts)
     render(PlenarioWeb.SharedView, "map.html", assigns)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.12.1"
+  @version "0.12.2"
 
   def project do
     [

--- a/priv/repo/migrations/000021_enable_tsm_system_rows.exs
+++ b/priv/repo/migrations/000021_enable_tsm_system_rows.exs
@@ -1,0 +1,9 @@
+defmodule Plenario.Repo.Migrations.EnableTsmSystemRows do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE EXTENSION IF NOT EXISTS tsm_system_rows;
+    """
+  end
+end

--- a/test/plenario_auth/abilities_test.exs
+++ b/test/plenario_auth/abilities_test.exs
@@ -15,6 +15,9 @@ defmodule PlenarioAuth.Testing.AbilitiesTest do
     {:ok, vdf} = VirtualDateFieldActions.create(meta, field.id)
     {:ok, vpf} = VirtualPointFieldActions.create(meta, field.id)
 
+    {:ok, meta} = MetaActions.submit_for_approval(meta)
+    {:ok, meta} = MetaActions.approve(meta)
+
     {:ok, [meta: meta, field: field, vdf: vdf, vpf: vpf]}
   end
 
@@ -92,6 +95,9 @@ defmodule PlenarioAuth.Testing.AbilitiesTest do
       {:ok, field} = DataSetFieldActions.create(meta, "name", "text")
       {:ok, vdf} = VirtualDateFieldActions.create(meta, field.id)
       {:ok, vpf} = VirtualPointFieldActions.create(meta, field.id)
+
+      {:ok, meta} = MetaActions.submit_for_approval(meta)
+      {:ok, meta} = MetaActions.approve(meta)
 
       {:ok, [new_meta: meta, new_field: field, new_vdf: vdf, new_vpf: vpf]}
     end


### PR DESCRIPTION
### New Map Defaults, Options

The reason the maps weren't showing up on the meta detail pages was
because the defaults for the maps was never set to match the style
updates on the front end. To fix this, I swapped the value from `500` to
`50vw`.

I also added a new option to the view to differentiate between point
data coming from AoT and regular data sets. AoT point data is richer --
it has node information and links attached to it. Meta point data is
just the coordinates.

With this new option, I added a random sampling of points from the data
set to the map in the detail view. It looks fuller and more pleasant.

In order to get efficient _random_ samples of data from Postgres, I
needed to enable the `tsm_system_rows` extension that provides this kind
of functionality. There's a migration to handle this.

### Added Maps to Search Results When No Charts

If a data set does not have charts defined for it, rather than having a
big blank space we now just throw the map of its points in.

To get this to work, I had to update the template's javascript to use
`var`s all over the place, since redeclaring stuff using `const` and
`let` is a no-no. I'm sure Ben will hammer me on this.

### Search Results

![screenshot_2018-07-17 plenario](https://user-images.githubusercontent.com/4360430/42850666-54792c58-89ee-11e8-88da-2392cbb9eb71.png)

### Meta Detail

![screenshot_2018-07-17 plenario 1](https://user-images.githubusercontent.com/4360430/42850692-6dd72948-89ee-11e8-9ed0-b45216ccbd98.png)

Closes #331 