### PR TITLE
Do Not Show "Request Changes" to Non-Owner Users in Data Set Show

### DIFF
--- a/lib/plenario_web/templates/web/data_set/show.html.eex
+++ b/lib/plenario_web/templates/web/data_set/show.html.eex
@@ -10,7 +10,7 @@
     <%= if @user_is_owner? and not Enum.member?(["new", "needs_approval", "erred"], @meta.state) do %>
       <%= button "Ingest Now", to: data_set_path(@conn, :ingest_now, @meta.id), class: "btn btn-primary" %>
     <% end %>
-    <%= if @meta.state != "new" do %>
+    <%= if @meta.state != "new" and @user_is_owner? do %>
       <%= link "Request Changes", to: data_set_path(@conn, :request_changes, @meta), class: "btn btn-danger",
       title: "Users must request changes to an administrator once a data set has been submitted or approved." %>
     <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.12.4"
+  @version "0.12.5"
 
   def project do
     [

--- a/test/plenario_web/controllers/web/data_set_controller_test.exs
+++ b/test/plenario_web/controllers/web/data_set_controller_test.exs
@@ -18,6 +18,40 @@ defmodule PlenarioWeb.Web.Testing.DataSetControllerTest do
     |> html_response(:ok)
   end
 
+  describe "data set show's request changes button" do
+    @tag :auth
+    test "should be available when the user owns the data set and it's not new", %{conn: conn, meta: meta} do
+      {:ok, meta} = MetaActions.submit_for_approval(meta)
+
+      resp =
+        conn
+        |> get(data_set_path(conn, :show, meta.id))
+        |> html_response(:ok)
+
+      assert resp =~ "Request Changes"
+    end
+
+    @tag :auth
+    test "should not be available when the user owns the data set and it's still new", %{conn: conn, meta: meta} do
+      resp =
+        conn
+        |> get(data_set_path(conn, :show, meta.id))
+        |> html_response(:ok)
+
+      refute resp =~ "Request Changes"
+    end
+
+    @tag :anon
+    test "should not be available when the user is not the owner", %{conn: conn, meta: meta} do
+      resp =
+        conn
+        |> get(data_set_path(conn, :show, meta.id))
+        |> html_response(:ok)
+
+      refute resp =~ "Request Changes"
+    end
+  end
+
   @tag :auth
   test "new", %{conn: conn} do
     conn


### PR DESCRIPTION
The _Request Changes_ button was being shown to all users regardless of
ownership when the data set was shown. If a non-owning user clicked the
button, it would 403.

While this is more or less the correct response, users shouldn't even be
aware of this option if they don't own the data set -- this is doubly
true for anonymous users.

This adds a simple condition to the template that ensures the user
attached to the request owns the data set -- there's a `@user_is_owner?`
variable assigned in the response anyway.

Fixes #378