### PR TITLE
Fix now-broken README logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="./assets/static/images/logo-large.png">
+  <img src="./assets/static/images/arch-md.png">
   <br>
   Plenario
 </h1>


### PR DESCRIPTION
Since #381 included upgraded/renamed image assets, it broke the readme header. I even had a sticky note on my monitor to not forget this 😫.