### PR TITLE
Fixes missing/garbage character tooltip icons

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -20,3 +20,9 @@ window.$ = $;
 window.Pikaday = Pikaday;
 window.throttle = throttle;
 window.debounce = debounce;
+
+// Tell FontAwesome to nest SVGs inside <i> tags, instead of replacing them
+window.FontAwesome.config.autoReplaceSvg = 'nest';
+
+// Tooltips are opt-in in Bootstrap 4, so we have to activate them
+$(() => $('[data-toggle="tooltip"]').tooltip());

--- a/lib/plenario_web/template_helpers.ex
+++ b/lib/plenario_web/template_helpers.ex
@@ -39,8 +39,12 @@ defmodule PlenarioWeb.TemplateHelpers do
   A helper function that generates a tooltip.
   """
   def tooltip(message) do
-    content_tag(:span, "🛈",
-      data: [toggle: "tooltip", placement: "top"],
+    content_tag(:i, "",
+      class: "fas fa-question-circle",
+      data: [
+        toggle: "tooltip",
+        "fa-transform": "shrink-4"
+      ],
       title: message)
   end
 


### PR DESCRIPTION
Also makes the tooltips actually work. They were never updated for Bootstrap 4 which made them an explicit opt-in behavior for performance reasons.

@vforgione @HeyZoos please give the whole site a once-over for other broken icons; I don't think anything depended on the replace-vs-nest FontAwesome default, but I missed this the first time so I don't necessarily trust my own inspection.

Actually closes #379 this time.