### PR TITLE
Fix Index Names

### DIFF
--- a/priv/db-actions/up/create-index.sql.eex
+++ b/priv/db-actions/up/create-index.sql.eex
@@ -1,4 +1,4 @@
-CREATE INDEX "idx_<%= view_name %>_<%= field.id %>"
+CREATE INDEX "idx_<%= view_name %>_<%= type %>_<%= id %>"
 ON "<%= view_name %>"
 <%= if using do %>USING <%= using %><% end %>
-("<%= field.name %>");
+("<%= name %>");

--- a/priv/db-actions/up/create-trgm-index.sql.eex
+++ b/priv/db-actions/up/create-trgm-index.sql.eex
@@ -1,3 +1,3 @@
-CREATE INDEX "idx_<%= view_name %>_<%= field.id %>"
+CREATE INDEX "idx_<%= view_name %>_<%= type %>_<%= id %>"
 ON "<%= view_name %>"
-USING GIN ( to_tsvector('english', "<%= field.name %>") )
+USING GIN ( to_tsvector('english', "<%= name %>") )


### PR DESCRIPTION
The way I reset the index names didn't guarantee unique names. I went
with the assumption that we wouldn't collide IDs in the names. Well,
running the seed script blew that to hell.

The index names are now `idx_{view name}_{field type abbrv}_{field id}`.
This should be unique now.

I also fixed up the seed script.

Fixes #390