### PR TITLE
Removed God Awful Explode Library

### DIFF
--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -1,15 +1,27 @@
 defmodule PlenarioWeb.Api.AotController do
+
   use PlenarioWeb, :api_controller
 
+  require Logger
+
   import Ecto.Query
+
   import Geo.PostGIS, only: [st_intersects: 2]
+
   import PlenarioWeb.Api.Plugs
-  import PlenarioWeb.Api.Utils, only: [render_page: 6]
+
+  import PlenarioWeb.Api.Utils, only: [
+    render_page: 6,
+    halt_with: 3
+  ]
 
   alias Plenario.Repo
-  alias PlenarioAot.{AotData, AotMeta, AotObservation}
 
-  require Logger
+  alias PlenarioAot.{
+    AotData,
+    AotMeta,
+    AotObservation
+  }
 
   plug :check_page
   plug :check_page_size, default_page_size: 500, page_size_limit: 5000
@@ -18,7 +30,7 @@ defmodule PlenarioWeb.Api.AotController do
     try do
       Poison.decode!(value) |> Geo.JSON.decode()
     rescue
-      _ -> conn |> Explode.with(400, "Unable to parse bounding box JSON or generate Geo object")
+      _ -> conn |> halt_with(400, "Unable to parse bounding box JSON or generate Geo object")
     end
   end
 
@@ -93,7 +105,7 @@ defmodule PlenarioWeb.Api.AotController do
       end
 
     case meta_ids do
-      nil -> conn |> Explode.with(400, "Unable to execute bounding box query")
+      nil -> conn |> halt_with(400, "Unable to execute bounding box query")
       _ -> meta_ids
     end
 

--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -1,9 +1,22 @@
 defmodule PlenarioWeb.Api.DetailController do
+
   use PlenarioWeb, :api_controller
+
   import PlenarioWeb.Api.Plugs
-  import PlenarioWeb.Api.Utils, only: [render_page: 5, map_to_query: 2]
-  alias Plenario.{ModelRegistry, Repo}
+
+  import PlenarioWeb.Api.Utils, only: [
+    render_page: 5,
+    map_to_query: 2,
+    halt_with: 2
+  ]
+
+  alias Plenario.{
+    ModelRegistry,
+    Repo
+  }
+
   alias Plenario.Actions.MetaActions
+
   alias PlenarioWeb.Controllers.Api.CaptureArgs
 
   defmodule CaptureColumnArgs do
@@ -15,7 +28,7 @@ defmodule PlenarioWeb.Api.DetailController do
     end
 
     def do_call(nil, conn, _opts) do
-        conn |> Explode.with(404, "Data set not found")
+        conn |> halt_with(:not_found)
     end
 
     def do_call(meta, conn, opts) do

--- a/lib/plenario_web/controllers/api/method_not_allowed_controller.ex
+++ b/lib/plenario_web/controllers/api/method_not_allowed_controller.ex
@@ -1,6 +1,8 @@
 defmodule PlenarioWeb.Api.MethodNotAllowedController do
   use PlenarioWeb, :api_controller
 
+  import PlenarioWeb.Api.Utils, only: [halt_with: 2]
+
   def match(%Plug.Conn{path_info: path_info} = conn, _params) do
     routes =
       PlenarioWeb.Router.__routes__()
@@ -11,9 +13,9 @@ defmodule PlenarioWeb.Api.MethodNotAllowedController do
       |> Enum.drop(1)))
 
     if path_info in routes do
-      conn |> Explode.with(405, "Method not allowed")
+      conn |> halt_with(:method_not_allowed)
     else
-      conn |> Explode.with(404, "Not found")
+      conn |> halt_with(:not_found)
     end
   end
 end

--- a/lib/plenario_web/controllers/api/plugs.ex
+++ b/lib/plenario_web/controllers/api/plugs.ex
@@ -1,5 +1,9 @@
 defmodule PlenarioWeb.Api.Plugs do
-  import Plug.Conn, only: [put_req_header: 3]
+
+  import PlenarioWeb.Api.Utils, only: [
+    halt_with: 3
+  ]
+
   alias Plug.Conn
 
   @doc """
@@ -34,12 +38,7 @@ defmodule PlenarioWeb.Api.Plugs do
         conn
       false ->
         conn
-        # Even if the request is asking for something else, we only serve json so we overwrite the
-        # header of the incoming request. This will definitely have to be changed later if we want
-        # to serve more than one media type. For most browsers, their default accept header prefers
-        # xml, and this can lead to some weirdly formatted errors.
-        |> put_req_header("accept", "application/vnd.api+json")
-        |> Explode.with(422, "Provided page_size '#{page_size}' must be between 0 and #{opts[:page_size_limit]}")
+        |> halt_with(422, "Provided page_size '#{page_size}' must be between 0 and #{opts[:page_size_limit]}")
     end
   end
 
@@ -53,12 +52,7 @@ defmodule PlenarioWeb.Api.Plugs do
         check_page_size(%{conn | params: Map.put(conn.params, "page_size", parsed_page_size)}, opts)
       :error ->
         conn
-        # Even if the request is asking for something else, we only serve json so we overwrite the
-        # header of the incoming request. This will definitely have to be changed later if we want
-        # to serve more than one media type. For most browsers, their default accept header prefers
-        # xml, and this can lead to some weirdly formatted errors.
-        |> put_req_header("accept", "application/vnd.api+json")
-        |> Explode.with(422, "Provided page_size '#{page_size}' must be a number.")
+        |> halt_with(422, "Provided page_size '#{page_size}' must be a number.")
     end
   end
 
@@ -97,13 +91,8 @@ defmodule PlenarioWeb.Api.Plugs do
   """
   def check_page(conn = %Conn{params: %{"page" => page}}, _) when is_integer(page) and page > 0, do: conn
   def check_page(conn = %Conn{params: %{"page" => page}}, _) when is_integer(page) and page <= 0 do
-    # Even if the request is asking for something else, we only serve json so we overwrite the
-    # header of the incoming request. This will definitely have to be changed later if we want
-    # to serve more than one media type. For most browsers, their default accept header prefers
-    # xml, and this can lead to some weirdly formatted errors.
     conn
-    |> put_req_header("accept", "application/vnd.api+json")
-    |> Explode.with(422, "Provided page '#{page}' must be positive.")
+    |> halt_with(422, "Provided page '#{page}' must be positive.")
   end
 
   @doc """
@@ -124,12 +113,7 @@ defmodule PlenarioWeb.Api.Plugs do
         check_page(%{conn | params: Map.put(conn.params, "page", parsed_page)}, opts)
       :error ->
         conn
-        # Even if the request is asking for something else, we only serve json so we overwrite the
-        # header of the incoming request. This will definitely have to be changed later if we want
-        # to serve more than one media type. For most browsers, their default accept header prefers
-        # xml, and this can lead to some weirdly formatted errors.
-        |> put_req_header("accept", "application/vnd.api+json")
-        |> Explode.with(422, "Provided page '#{page}' must be a number.")
+        |> halt_with(422, "Provided page '#{page}' must be a number.")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,6 @@ defmodule Plenario.Mixfile do
 
       # http and api utils
       {:cors_plug, "~> 1.5"},
-      {:explode, "~> 1.0.0"},
 
       # Parsing libraries
       {:csv, "~> 2.0"},          # csv


### PR DESCRIPTION
Just... wow. What an unbelievable pile of turds.

Rather than relying on a library that was clearly developed by a high
schooler, we're going to be smart about this and **just use the
functions and modules Plug already gives us**.

Plug gives us the ability to:

- set the resonse content type we want
- set the status code and message
- get an appropriate status code by either its integer value or atom
- get an appropriate message for that code
- halt further processing

We have no reason to ever consider what the client accepts via our API
because its documented to be strictly `application/json`. Clients should
only expect that content type. And overriding the `accept` content type
the client sends is a massive violation of the client/server contract.

Beyond that, as the title of the issue this solves indicates, **we do
not serve up JSON+API content**.

This whole thing went way sideways -- mainly because of good intentions
to be helpful and give clients verbose error messages. This fixes that.
We _can_ be helpful and not rely on shity anti-patterns at the same
time.

Fixes #348