### PR TITLE
Fixed Erlang/NaiveDateTime Casting Error

### DIFF
--- a/lib/plenario_web/controllers/web/page_controller.ex
+++ b/lib/plenario_web/controllers/web/page_controller.ex
@@ -7,7 +7,7 @@ defmodule PlenarioWeb.Web.PageController do
   alias Plenario.Repo
   alias PlenarioAot.{AotData, AotMeta}
 
-  def assign_s3_path(conn, opts) do
+  def assign_s3_path(conn, _opts) do
     assign(
       conn,
       :s3_asset_path,

--- a/lib/postgres_extensions.ex
+++ b/lib/postgres_extensions.ex
@@ -64,16 +64,29 @@ defmodule Plenario.TsRange do
     }
   end
 
+  defp to_erl({ymd, {h, m, s}}), do: {ymd, {h, m, s, 0}}
+
   defp to_erl({{_, _, }, {_, _, _, _}} = erl), do: erl
+
   defp to_erl(%NaiveDateTime{} = d) do
     {ymd, {h, m, s}} = NaiveDateTime.to_erl(d)
     {ymd, {h, m, s, 0}}
   end
 
   defp from_erl(%NaiveDateTime{} = ndt), do: ndt
+
+  defp from_erl({{y, m, d}, {h, i, s}}) do
+    case NaiveDateTime.new(y, m, d, h, i, s, {0, 0}) do
+      {:ok, n} -> n
+      _ -> nil
+    end
+  end
+
   defp from_erl({{y, m, d}, {h, i, s, u}}) do
-    {:ok, n} = NaiveDateTime.new(y, m, d, h, i, s, {u, 0})
-    n
+    case NaiveDateTime.new(y, m, d, h, i, s, {u, 0}) do
+      {:ok, n} -> n
+      _ -> nil
+    end
   end
 
   defimpl String.Chars, for: Plenario.TsRange do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.13.5"
+  @version "0.13.6"
 
   def project do
     [


### PR DESCRIPTION
The functions in TsRange are relatively robust and should be able to
handle casts from erl dates to NaiveDateTimes. Unfortunately, there were
some edge cases in the database returns that didn't include
microseconds, and in a few other situtations we had abysmally formatted
dates in data files from sources.

This covers both edges. I added two new pattern matches to the casting and
wrapped the parsing in case statements defaulting to nil.

I also suppressed a compiler warning (it was irritating me).

Fixes #395