### PR TITLE
421 Document API Helper Funcs

### DIFF
--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -14,8 +14,8 @@ defmodule PlenarioWeb.Api.DetailController do
       halt_with: 2,
       halt_with: 3,
       render_detail: 3,
-      validate_data_set: 1,
-      validate_data_set: 2
+      validate_slug_get_meta: 1,
+      validate_slug_get_meta: 2
     ]
 
   alias Plenario.{
@@ -32,19 +32,19 @@ defmodule PlenarioWeb.Api.DetailController do
 
   @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def get(conn, %{"slug" => slug}) do
-    validate_data_set(slug)
+    validate_slug_get_meta(slug)
     |> render_data_set(conn, "get.json")
   end
 
   @spec head(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def head(conn, %{"slug" => slug}) do
-    validate_data_set(slug)
+    validate_slug_get_meta(slug)
     |> render_data_set(conn, "head.json")
   end
 
   def describe(conn, %{"slug" => slug}) do
     meta =
-      validate_data_set(
+      validate_slug_get_meta(
         slug,
         with_user: true,
         with_fields: true,

--- a/lib/plenario_web/views/api/view_utils.ex
+++ b/lib/plenario_web/views/api/view_utils.ex
@@ -1,8 +1,44 @@
 defmodule PlenarioWeb.Api.ViewUtils do
+  @moduledoc """
+  This module contains functions that are universally beneficial to API Views. These are functions
+  that are used to format and clean responses.
+  """
+
+  @scrub_keys [
+    :__meta__,
+    :__struct__,
+    :id,
+    :inserted_at,
+    :updated_at,
+    :source_type,
+    :table_name,
+    :state,
+    :user_id,
+    :meta_id,
+    :aot_meta_id,
+    :password,
+    :password_hash
+  ]
+
+  @scrub_values [
+    Ecto.Association.NotLoaded,
+    Plug.Conn
+  ]
+
+  @doc """
+  This function takes either a list of maps or a single map (map being either a literal map or a
+  struct) and scrubs undesirable key/value pairs from it. Things like `__meta__` keys and
+  `%Ecto.Association.NotLoaded{}` either bleed too much information and/or have serialization
+  issues.
+
+  See the module attributes `@scrub_keys` and `@scrub_values`.
+  """
+  @spec clean(list(map())) :: list(map())
   def clean(records) when is_list(records) do
     clean(records, [])
   end
 
+  @spec clean(map()) :: map()
   def clean(record) when is_map(record) do
     Map.to_list(record)
     |> Enum.filter(fn {key, value} -> is_clean(key, value) end)
@@ -18,24 +54,13 @@ defmodule PlenarioWeb.Api.ViewUtils do
     clean(tail, [cleaned | acc])
   end
 
-  defp is_clean(_, %Ecto.Association.NotLoaded{}), do: false
-  defp is_clean(_, %Plug.Conn{}), do: false
+  for key <- @scrub_keys do
+    defp is_clean(unquote(key), _), do: false
+  end
 
-  defp is_clean(key, _)
-       when key in [
-              :__meta__,
-              :__struct__,
-              :id,
-              :inserted_at,
-              :updated_at,
-              :source_type,
-              :table_name,
-              :state,
-              :user_id,
-              :meta_id,
-              :aot_meta_id
-            ],
-       do: false
+  for value <- @scrub_values do
+    defp is_clean(_, %unquote(value){}), do: false
+  end
 
   defp is_clean(_, _), do: true
 end


### PR DESCRIPTION
## Cleaned and Documented API View Utils

I added docs and specs to the public functions and updated the private
`is_clean` function to be built at compile time using lists of keys and
values to define dirty types. The beauty of this is that we can just
keep updating those lists as needed without having to touch the
functions.

##  Added Docs to Controller Utils and Renamed a Function

Let's start with the rename -- `validate_data_set` was a really awful
choice for what the function took as a parameter and what it returned.
The new name, `validate_slug_get_meta` tells you _exactly_ what it does.

I also added docs for all public functions.

## Added Docs to API Plugs 

Closes #421 