### PR TITLE
Fix @head Directive Counts

### DIFF
--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -207,6 +207,13 @@ defmodule PlenarioWeb.Api.Utils do
           total_records: 1
         }
 
+      "head.json" ->
+        %{
+          data_count: 1,
+          total_pages: 1,
+          total_records: page.total_entries
+        }
+
       _ ->
         %{
           data_count: length(page.entries),

--- a/lib/plenario_web/controllers/api/utils.ex
+++ b/lib/plenario_web/controllers/api/utils.ex
@@ -200,25 +200,18 @@ defmodule PlenarioWeb.Api.Utils do
 
   defp make_counts(view, page) do
     case view do
-      "describe.json" ->
+      "get.json" ->
         %{
-          data_count: 1,
-          total_pages: 1,
-          total_records: 1
-        }
-
-      "head.json" ->
-        %{
-          data_count: 1,
-          total_pages: 1,
+          data_count: length(page.entries),
+          total_pages: page.total_pages,
           total_records: page.total_entries
         }
 
       _ ->
         %{
-          data_count: length(page.entries),
-          total_pages: page.total_pages,
-          total_records: page.total_entries
+          data_count: 1,
+          total_pages: 1,
+          total_records: 1
         }
     end
   end

--- a/test/plenario_web/controllers/api/list_controller_test.exs
+++ b/test/plenario_web/controllers/api/list_controller_test.exs
@@ -240,5 +240,18 @@ defmodule PlenarioWeb.Api.ListControllerTest do
       res["data"]
       |> Enum.each(&assert Map.keys(&1) == @record_keys)
     end
+
+    test "the meta.counts are accurate to response", %{conn: conn} do
+      res =
+        conn
+        |> get(list_path(conn, :head))
+        |> json_response(:ok)
+
+      assert res["meta"]["counts"] == %{
+               "data_count" => 1,
+               "total_pages" => 1,
+               "total_records" => 1
+             }
+    end
   end
 end


### PR DESCRIPTION
The `meta.counts` object had inaccurate informaiton in it. This ensures
that the data count is 1 (because it is), and the total pages is 1
(because there is only one page of results in a head call), and the
total entries is what is actually in the database.

Fixes #428