### PR TITLE
Updated API Status Codes and Terminal Pagination

### DIFF
--- a/lib/plenario_web/controllers/api/aot_controller.ex
+++ b/lib/plenario_web/controllers/api/aot_controller.ex
@@ -55,7 +55,7 @@ defmodule PlenarioWeb.Api.AotController do
     |> Enum.reduce(AotMeta, fn {fname, op, value}, query ->
       apply_filter(query, fname, op, value)
     end)
-    |> Repo.paginate(page: page, page_size: page_size)
+    |> Repo.paginate(page_number: page, page_size: page_size)
     |> render_aot(conn, "describe.json")
   end
 
@@ -95,7 +95,7 @@ defmodule PlenarioWeb.Api.AotController do
     try do
       page = conn.assigns[:page]
       page_size = conn.assigns[:page_size]
-      data = Repo.paginate(query, page: page, page_size: page_size)
+      data = Repo.paginate(query, page_number: page, page_size: page_size)
       {:ok, data}
     rescue
       e in [Ecto.QueryError, Ecto.SubQueryError, Postgrex.Error] ->

--- a/lib/plenario_web/controllers/api/detail_controller.ex
+++ b/lib/plenario_web/controllers/api/detail_controller.ex
@@ -74,7 +74,7 @@ defmodule PlenarioWeb.Api.DetailController do
     try do
       page = conn.assigns[:page]
       page_size = conn.assigns[:page_size]
-      data = Repo.paginate(query, page: page, page_size: page_size)
+      data = Repo.paginate(query, page_number: page, page_size: page_size)
       render_detail(conn, view, data)
     rescue
       e in [Ecto.QueryError, Ecto.SubQueryError, Postgrex.Error] ->

--- a/lib/plenario_web/controllers/api/list_controller.ex
+++ b/lib/plenario_web/controllers/api/list_controller.ex
@@ -49,7 +49,7 @@ defmodule PlenarioWeb.Api.ListController do
     try do
       page = conn.assigns[:page]
       page_size = conn.assigns[:page_size]
-      data = Repo.paginate(query, page: page, page_size: page_size)
+      data = Repo.paginate(query, page_number: page, page_size: page_size)
       render_list(conn, view, data)
     rescue
       e in [Ecto.QueryError, Ecto.SubQueryError, Postgrex.Error] ->

--- a/lib/plenario_web/controllers/api/plugs.ex
+++ b/lib/plenario_web/controllers/api/plugs.ex
@@ -48,11 +48,11 @@ defmodule PlenarioWeb.Api.Plugs do
 
   def check_page_size(%Conn{params: %{"page_size" => size}} = conn, _opts)
       when is_integer(size) and size > @max_page_size,
-      do: halt_with(conn, :bad_request, @page_size_error)
+      do: halt_with(conn, :forbidden, @page_size_error)
 
   def check_page_size(%Conn{params: %{"page_size" => size}} = conn, _opts)
       when is_integer(size) and size <= 0,
-      do: halt_with(conn, :bad_request, @page_size_error)
+      do: halt_with(conn, :unprocessable_entity, @page_size_error)
 
   def check_page_size(%Conn{params: %{"page_size" => size}} = conn, _opts) when is_bitstring(size) do
     case Integer.parse(size) do
@@ -100,7 +100,7 @@ defmodule PlenarioWeb.Api.Plugs do
 
   def check_page(%Conn{params: %{"page" => page}} = conn, _opts)
       when is_integer(page) and page <= 0,
-      do: halt_with(conn, :bad_request, @page_error)
+      do: halt_with(conn, :unprocessable_entity, @page_error)
 
   def check_page(%Conn{params: %{"page" => page}} = conn, _opts) when is_bitstring(page) do
     case Integer.parse(page) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plenario.Mixfile do
   use Mix.Project
 
-  @version "0.16.1"
+  @version "0.16.2"
 
   def project do
     [

--- a/test/plenario_web/controllers/api/plugs_test.exs
+++ b/test/plenario_web/controllers/api/plugs_test.exs
@@ -92,16 +92,16 @@ defmodule PlenarioWeb.Api.PlugsTest do
       assert res["meta"]["params"]["page_size"] == 200
     end
 
-    test "when given a value too large will :bad_request", %{conn: conn, meta: meta} do
+    test "when given a value too large will :forbidden", %{conn: conn, meta: meta} do
       conn
       |> get(detail_path(conn, :get, meta.slug, %{page_size: 1_000_000}))
-      |> json_response(:bad_request)
+      |> json_response(:forbidden)
     end
 
-    test "when given a value too little will :bad_request", %{conn: conn, meta: meta} do
+    test "when given a value too little will :unprocessable_entity", %{conn: conn, meta: meta} do
       conn
       |> get(detail_path(conn, :get, meta.slug, %{page_size: 0}))
-      |> json_response(:bad_request)
+      |> json_response(:unprocessable_entity)
     end
 
     test "when given a value not an integer will :bad_request", %{conn: conn, meta: meta} do
@@ -127,10 +127,10 @@ defmodule PlenarioWeb.Api.PlugsTest do
       assert res["meta"]["params"]["page"] == 1
     end
 
-    test "when given a value too little will :bad_request", %{conn: conn, meta: meta} do
+    test "when given a value too little will :unprocessable_entity", %{conn: conn, meta: meta} do
       conn
       |> get(detail_path(conn, :get, meta.slug, %{page: -1}))
-      |> json_response(:bad_request)
+      |> json_response(:unprocessable_entity)
     end
 
     test "when given a value not an integer will :bad_request", %{conn: conn, meta: meta} do


### PR DESCRIPTION
- `page_size=wrong` will 400 because it's syntactically incorrect
- `page_size=0,-1` will 422 because it's semantically incorrect
- `page_size=999999999` will 403 because we refuse to serve that large a page size
- `page=wrong` will 400 because it's syntactically incorrect
- `page=0,-1` will 422 because it's semantically incorrect
- `page=99999999` will 200 and server the last useful page of data

Fixes #420