### PR TITLE
Updates to help Alieviate Data Set Errors

### DIFF
--- a/lib/plenario/actions/meta_actions.ex
+++ b/lib/plenario/actions/meta_actions.ex
@@ -354,7 +354,7 @@ defmodule Plenario.Actions.MetaActions do
 
   defp do_get_points(nil, _, _), do: []
 
-  defp do_get_points(pt, meta, limit) do
+  defp do_get_points(pt, %Meta{state: "ready"} = meta, limit) do
     # we need to use a raw query here to harness the
     # tablesample selection in postgres.
     query = """
@@ -371,4 +371,6 @@ defmodule Plenario.Actions.MetaActions do
       "[#{lat}, #{lon}]"
     end)
   end
+
+  defp do_get_points(_, _, _), do: []
 end

--- a/lib/plenario/changesets/meta_changesets.ex
+++ b/lib/plenario/changesets/meta_changesets.ex
@@ -57,6 +57,7 @@ defmodule Plenario.Changesets.MetaChangesets do
     |> validate_required(@required_keys)
     |> unique_constraint(:source_url)
     |> unique_constraint(:name)
+    |> validate_length(:name, max: 58)
     |> cast_assoc(:user)
     |> test_source_url()
     |> validate_source_type()
@@ -71,6 +72,7 @@ defmodule Plenario.Changesets.MetaChangesets do
     |> validate_required(@required_keys)
     |> unique_constraint(:source_url)
     |> unique_constraint(:name)
+    |> validate_length(:name, max: 58)
     |> cast_assoc(:user)
     |> validate_state()
     |> test_source_url()
@@ -79,6 +81,7 @@ defmodule Plenario.Changesets.MetaChangesets do
     |> validate_refresh_interval()
     |> validate_refresh_ends_on()
     |> set_slug()
+    |> set_table_name()
   end
 
   defp validate_state(%Ecto.Changeset{valid?: true, changes: changes} = changeset) do

--- a/test/plenario/actions/data_set_actions_test.exs
+++ b/test/plenario/actions/data_set_actions_test.exs
@@ -80,7 +80,7 @@ defmodule Plenario.Actions.DataSetActionsTest do
   # each index is given a unique name, even in the event of an overflow
   # and truncation.
   test "up! with really long names", %{meta: meta} do
-    {:ok, meta} = MetaActions.update(meta, name: "blah blah blah blah blah blah blah blah blah blah blah blah blah")
+    {:ok, meta} = MetaActions.update(meta, name: "blah blah blah blah")
     {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 1", "text")
     {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 2", "text")
     {:ok, _} = DataSetFieldActions.create(meta, "derp derp derp derp derp derp derp derp derp derp derp 3", "text")


### PR DESCRIPTION
There were a bunch of errors when bringing up some of the Chicago data sets. This will take care of most of them.

We are still going to not be able to ingest Divvy, Crime and Taxi data until we get a Socrata direct strategy.

## Fixed Meta Detail Rendering Bug

The original signature didn't account for the function being called when
the data set was still empty. This corrects that. 

## Set Max Name Length

TIL Postgres has a maximum table name length of 63 characters. I set an
upper bound of 58 on the name length of the MetaChangeset. Why 58 and
not 63? Because when we create the materialized view for the data set we
tack on "_view" to the table name.

Updates #235 