### PR TITLE
Updated Data Set Export

### DIFF
--- a/lib/plenario_web/templates/web/page/explorer.html.eex
+++ b/lib/plenario_web/templates/web/page/explorer.html.eex
@@ -93,10 +93,10 @@
           </p>
           <hr>
           <p>
-            <%= button "View Details", to: data_set_path(@conn, :show, res.id), method: :get, class: "btn btn-primary" %>
+            <%= link "View Details", to: data_set_path(@conn, :show, res.id), method: :get, class: "btn btn-primary" %>
           </p>
           <p>
-            <%= button "Export to CSV", to: export_path(@conn, :export_meta, res.id), class: "btn btn-outline-primary" %>
+            <%= link "Download a Copy", to: res.source_url, target: "_blank", class: "btn btn-outline-primary" %>
           </p>
         </div>
         <div class="col-lg-9">


### PR DESCRIPTION
Since we don't really have all that great of an export strategy anymore
(we've made a lot of changes to our IO workers without giving any love
to the export process), it just makes sense at the moment to open a
blank tab and send the user to the source document.

I've updated the name of the link to _Download a Copy_ rather than
exporting to make it not seem like the users are going to just get a
view of the data set that matches their query -- the ideal export
functionality.

This still needs to fixed soon, but as we are rapidly approaching
release I don't want to screw around with big stuff like this.

Updates #371